### PR TITLE
fix: add trustHost configuration to NextAuth for production signOut

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -43,6 +43,7 @@ async function refreshAccessToken(token: JWT) {
 }
 
 export const { handlers, signIn, signOut, unstable_update, auth } = NextAuth({
+  trustHost: true,
   providers: [
     Credentials({
       credentials: {


### PR DESCRIPTION
## Summary
  - Add `trustHost: true` to NextAuth configuration in `auth.ts`
  - Fixes signOut not working in production deployment (Vercel)

  ## Problem
  User reported that the logout button doesn't work in production - the session persists even after clicking logout.

  ## Root Cause
  NextAuth v5 requires `trustHost: true` configuration for production environments to properly handle CSRF protection and cookie clearing
  across different hosts.

  ## Solution
  Added `trustHost: true` to the NextAuth configuration object in `src/auth.ts:46`.

  ## Test Plan
  - [x] Code review
  - [x] Deploy to production
  - [x] Test logout functionality in production environment
  - [x] Verify session is properly cleared after logout

  🤖 Generated with [Claude Code](https://claude.com/claude-code)
