### PR TITLE
feat: book creation enhancements and session management improvements

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,13 +9,14 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'childrens-book-files.s3.ap-northeast-2.amazonaws.com',
         port: '',
-        pathname: '/**', // 해당 호스트의 모든 경로 이미지를 허용
+        pathname: '/**',
       },
-      // 여기에 다른 이미지 도메인을 필요에 따라 추가할 수 있습니다.
-      // {
-      //   protocol: 'https',
-      //   hostname: 'another-domain.com',
-      // },
+      {
+        protocol: 'https',
+        hostname: 'via.placeholder.com',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -1,12 +1,13 @@
 import CreateBookButton from '@/components/book/create-book-button';
 import BookThumbnail from '@/components/mypage/book-thumbnail';
-import Link from 'next/link';
+import { BookStatus } from '@/types/api';
 
 // 예시 데이터: 실제로는 DB에서 동화책 목록을 가져와야 합니다.
 const sampleBooks = [
   {
     id: '83d1db29-49d5-4400-86e3-89e0e313a2eb',
     title: '귀여운 고양이',
+    status: 'COMPLETED',
     thumbnailUrl:
       'https://childrens-book-files.s3.ap-northeast-2.amazonaws.com/books/83d1db29-49d5-4400-86e3-89e0e313a2eb/images/cover.png', // 실제 이미지 경로로 변경
     visibility: 'PUBLIC' as const,
@@ -14,6 +15,7 @@ const sampleBooks = [
   {
     id: '95470e94-fa28-463f-8195-39cef43583d5',
     title: '용감한 토끼의 당근찾기 모험',
+    status: 'COMPLETED',
     thumbnailUrl:
       'https://childrens-book-files.s3.ap-northeast-2.amazonaws.com/books/95470e94-fa28-463f-8195-39cef43583d5/images/cover.png',
     visibility: 'PUBLIC' as const,
@@ -21,6 +23,7 @@ const sampleBooks = [
   {
     id: 'c5b013df-2d92-47ab-9996-af4a719cd17a',
     title: '귀여운 강아지',
+    status: 'COMPLETED',
     thumbnailUrl:
       'https://childrens-book-files.s3.ap-northeast-2.amazonaws.com/books/95470e94-fa28-463f-8195-39cef43583d5/images/cover.png',
     visibility: 'PUBLIC' as const,
@@ -54,6 +57,7 @@ const BooksPage = () => {
               id={book.id}
               thumbnailUrl={book.thumbnailUrl}
               title={book.title}
+              status={book.status as BookStatus}
               isPublic={book.visibility}
               showStatusButtons={false} // 공개 페이지에서는 상태 버튼 숨김
             />

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -27,8 +27,8 @@ export default async function LibraryPage({
   const dehydratedState = dehydrate(queryClient);
 
   return (
-    <main className="max-w-7xl mx-auto p-6 md:p-8 my-8">
-      <div className="mb-6 flex items-end justify-between">
+    <main className="flex flex-col items-center py-6 px-40 my-8">
+      <div className="w-full mb-6 flex items-end justify-between">
         <div>
           <h1 className="text-4xl font-bold text-gray-900 mb-3">동화 광장</h1>
           <p className="text-lg text-gray-600">

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -14,7 +14,9 @@ export default async function MyPage() {
   try {
     await Promise.all([
       queryClient.prefetchQuery(userProfileOption(session?.accessToken)),
-      queryClient.prefetchInfiniteQuery(myBookOption(session?.accessToken)),
+      queryClient.prefetchInfiniteQuery(
+        myBookOption(session?.accessToken, 'createdAt,desc')
+      ),
     ]);
   } catch (err) {
     console.error('userprofile prefetch failed', err);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -135,17 +135,17 @@ export const { handlers, signIn, signOut, unstable_update, auth } = NextAuth({
 
       const refreshedToken = await refreshPromise;
       if (refreshedToken.error) {
-        console.log('refreshToken error', refreshedToken);
-        // Don't return null - return token with error flag so session can handle it
-        return { ...token, error: 'RefreshAccessTokenError' };
+        console.log('refreshToken error - invalidating session');
+        // Return null to invalidate session
+        return null;
       }
 
       return refreshedToken;
     },
     async session({ session, token }) {
+      // JWT callback이 null을 반환하면 이 callback은 호출되지 않음
       session.user = token.user;
       session.accessToken = token.accessToken;
-      session.error = token.error;
 
       return session;
     },

--- a/src/components/library/book-detail-info.tsx
+++ b/src/components/library/book-detail-info.tsx
@@ -281,7 +281,7 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
   if (!postData) return <p>책을 찾을 수 없습니다.</p>;
 
   const handleMouseEnter = () => {
-    queryClient.prefetchQuery(bookDetailOption(slug));
+    queryClient.prefetchQuery(bookDetailOption(postData.book.bookId));
   };
 
   const handleLike = async () => {

--- a/src/components/library/book-detail-info.tsx
+++ b/src/components/library/book-detail-info.tsx
@@ -1,20 +1,27 @@
 'use client';
 
 import Image from 'next/image';
-import { FaStar, FaHeart, FaRegHeart, FaShare, FaTrash } from 'react-icons/fa';
+import {
+  FaStar,
+  FaHeart,
+  FaRegHeart,
+  FaShare,
+  FaTrash,
+  FaEdit,
+} from 'react-icons/fa';
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { getQueryClient } from '@/lib/get-query-client';
 import { libraryDetailBookOption } from './library-detail-book-option';
 import { libraryDetailLikeOption } from '@/components/library/library-detail-like-option';
 import { bookDetailOption } from '../book/book-detail-option';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useSession } from 'next-auth/react';
-import { ApiResponse, LikeData } from '@/types/api';
+import { ApiResponse, LikeData, PostDetailData } from '@/types/api';
 import useUserStore from '@/store/use-user-store';
 import useModalStore from '@/store/use-modal-store';
 import { useRouter } from 'next/navigation';
 import DeletePostModal from '@/components/ui/modal/delete-post-modal';
+import EditPostModal from '@/components/ui/modal/edit-post-modal';
 
 interface BookDetailInfoProps {
   slug: string;
@@ -22,8 +29,7 @@ interface BookDetailInfoProps {
 
 export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
   const [isLiked, setIsLiked] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const queryClient = getQueryClient();
+  const queryClient = useQueryClient();
   const { data: session } = useSession();
   const { user } = useUserStore();
   const { openModal, closeModal } = useModalStore();
@@ -119,6 +125,151 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
     },
   });
 
+  const { mutate: updateBookDetail, isPending: isUpdating } = useMutation({
+    mutationFn: async ({
+      title,
+      content,
+    }: {
+      title: string;
+      content: string;
+    }) => {
+      try {
+        if (!session?.accessToken) {
+          throw new Error('인증 정보가 없습니다.');
+        }
+        const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/posts/${slug}`;
+        const response = await fetch(backendUrl, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session?.accessToken}`,
+          },
+          body: JSON.stringify({ title, content }),
+        });
+
+        if (!response.ok) {
+          throw new Error('게시글을 수정할 수 없습니다.');
+        }
+
+        const data: ApiResponse<PostDetailData> = await response.json();
+        if (data.code !== 'POST_2002') {
+          throw new Error(data?.message || '게시글 수정 실패');
+        }
+
+        return data.data;
+      } catch (err) {
+        console.log('api call failed in parent', err);
+        throw err;
+      }
+    },
+    onMutate: async (variables) => {
+      const { title, content } = variables;
+      await queryClient.cancelQueries({
+        queryKey: ['library-detail-book', slug],
+      });
+      const previousData = queryClient.getQueryData<PostDetailData>([
+        'library-detail-book',
+        slug,
+      ]);
+
+      queryClient.setQueryData<PostDetailData>(
+        ['library-detail-book', slug],
+        (oldData) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            title,
+            content,
+          };
+        }
+      );
+      return { previousData };
+    },
+    onError: (err, variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(
+          ['library-detail-book', slug],
+          context.previousData
+        );
+      }
+      console.error('게시글 수정 실패:', err);
+      alert('게시글 수정에 실패했습니다. 다시 시도해주세요.');
+    },
+    onSuccess: () => {
+      closeModal();
+      alert('게시글이 수정되었습니다.');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['library-detail-book', slug],
+      });
+    },
+  });
+
+  const { mutate: deleteBookDetail, isPending: isDeleting } = useMutation({
+    mutationFn: async () => {
+      try {
+        if (!session?.accessToken) {
+          throw new Error('인증 정보가 없습니다.');
+        }
+
+        const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/posts/${slug}`;
+        const response = await fetch(backendUrl, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session?.accessToken}`,
+          },
+        });
+
+        if (!response.ok) {
+          throw new Error('게시글을 삭제할 수 없습니다.');
+        }
+
+        const data: ApiResponse<null> = await response.json();
+        if (data.code !== 'POST_2003') {
+          throw new Error(data?.message || '게시글 삭제 실패');
+        }
+
+        return data.data;
+      } catch (err) {
+        console.log('api call failed in parent', err);
+        throw err;
+      }
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: ['library-detail-book', slug],
+      });
+      const previousData = queryClient.getQueryData<PostDetailData>([
+        'library-detail-book',
+        slug,
+      ]);
+      queryClient.setQueryData(['library-detail-book', slug], null);
+      return { previousData };
+    },
+    onError: (err, variables, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(
+          ['library-detail-book', slug],
+          context.previousData
+        );
+      }
+      console.error('게시글 삭제 실패:', err);
+      alert('게시글 삭제에 실패했습니다. 다시 시도해주세요.');
+    },
+    onSuccess: () => {
+      closeModal();
+      alert('게시글이 삭제되었습니다.');
+      router.push('/library');
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['library-detail-book', slug],
+      });
+    },
+  });
+
   useEffect(() => {
     if (likeData) {
       setIsLiked(likeData.isLiked);
@@ -158,6 +309,7 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
   };
 
   const handleDeleteClick = () => {
+    if (!postData) return;
     openModal(
       <DeletePostModal
         title={postData.book.originalTitle}
@@ -169,37 +321,24 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
   };
 
   const handleDeleteConfirm = async () => {
-    try {
-      setIsDeleting(true);
+    deleteBookDetail();
+  };
 
-      if (!session?.accessToken) {
-        throw new Error('인증 정보가 없습니다.');
-      }
+  const handleEditClick = () => {
+    if (!postData) return;
+    openModal(
+      <EditPostModal
+        initialTitle={postData.title}
+        initialContent={postData.content}
+        onConfirm={handleEditConfirm}
+        onCancel={closeModal}
+      />,
+      { size: 'md' }
+    );
+  };
 
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/api/v1/posts/${slug}`,
-        {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${session.accessToken}`,
-          },
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error('게시글 삭제에 실패했습니다.');
-      }
-
-      closeModal();
-      alert('게시글이 삭제되었습니다.');
-      router.push('/library');
-    } catch (error) {
-      console.error('게시글 삭제 실패:', error);
-      alert('게시글 삭제에 실패했습니다. 다시 시도해주세요.');
-    } finally {
-      setIsDeleting(false);
-    }
+  const handleEditConfirm = async (title: string, content: string) => {
+    updateBookDetail({ title, content });
   };
 
   const isAuthor = user && postData && user.id === postData.authorId;
@@ -306,14 +445,24 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
             </button>
 
             {isAuthor && (
-              <button
-                onClick={handleDeleteClick}
-                disabled={isDeleting}
-                className="flex items-center justify-center gap-2 px-4 py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <FaTrash />
-                삭제
-              </button>
+              <>
+                <button
+                  onClick={handleEditClick}
+                  disabled={isUpdating}
+                  className="flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 text-white rounded-lg font-semibold hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <FaEdit />
+                  수정
+                </button>
+                <button
+                  onClick={handleDeleteClick}
+                  disabled={isDeleting}
+                  className="flex items-center justify-center gap-2 px-4 py-3 bg-red-600 text-white rounded-lg font-semibold hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <FaTrash />
+                  삭제
+                </button>
+              </>
             )}
           </div>
         </div>

--- a/src/components/library/library-book-list.tsx
+++ b/src/components/library/library-book-list.tsx
@@ -4,55 +4,17 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { useInView } from 'react-intersection-observer';
 import { Fragment, useEffect } from 'react';
 import LibraryBookCard from './library-book-card';
-import { ApiResponse, LibraryBookListData } from '@/types/api';
+import { libraryBookOption } from './library-book-option';
 
 interface LibraryBookListProps {
   currentSort: string;
 }
 
-// API 호출 함수 (백엔드에서 실제 데이터 가져올 때 사용)
-const fetchLibraryBooks = async ({
-  pageParam = 0,
-  sort = 'latest',
-}: {
-  pageParam?: number;
-  sort?: string;
-}) => {
-  const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/library/posts?page=${pageParam}&size=5&sort=${sort}`;
-  const response = await fetch(backendUrl, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
-  if (!response.ok) {
-    throw new Error('책 데이터를 불러올 수 없습니다');
-  }
-
-  const data: ApiResponse<LibraryBookListData> = await response.json();
-  if (!data.data) {
-    throw new Error('책 데이터가 없습니다.');
-  }
-  return data.data;
-};
-
 const LibraryBookList = ({ currentSort }: LibraryBookListProps) => {
   const { ref, inView } = useInView({ threshold: 0.5 });
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } =
-    useInfiniteQuery({
-      queryKey: ['library-books'],
-      queryFn: async ({ pageParam = 0 }) => {
-        return await fetchLibraryBooks({
-          pageParam: pageParam,
-          sort: currentSort,
-        });
-      },
-      initialPageParam: 0,
-      getNextPageParam: (lastPage) => {
-        return !lastPage.isLast ? lastPage.currentPage + 1 : undefined;
-      },
-    });
+    useInfiniteQuery(libraryBookOption(currentSort));
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
@@ -93,9 +55,9 @@ const LibraryBookList = ({ currentSort }: LibraryBookListProps) => {
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
         {data.pages.map((page, pageIndex) => (
           <Fragment key={pageIndex}>
-            {page.posts.map((post, i) => (
+            {page.posts.map((post) => (
               <LibraryBookCard
-                key={i}
+                key={post.postId}
                 post={post}
               />
             ))}

--- a/src/components/library/library-book-list.tsx
+++ b/src/components/library/library-book-list.tsx
@@ -22,62 +22,66 @@ const LibraryBookList = ({ currentSort }: LibraryBookListProps) => {
     }
   }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  if (isLoading) {
-    return (
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
-        {[...Array(10)].map((_, i) => (
-          <div
-            key={i}
-            className="animate-pulse"
-          >
-            <div className="bg-gray-300 aspect-[3/4] rounded-lg mb-3"></div>
-            <div className="bg-gray-300 h-4 rounded mb-2"></div>
-            <div className="bg-gray-300 h-3 rounded w-2/3"></div>
-          </div>
-        ))}
-      </div>
-    );
-  }
-
   const noBooks =
     !data || data.pages.length === 0 || data.pages[0].posts.length === 0;
 
-  if (noBooks) {
-    return (
-      <div className="text-center py-20">
-        <p className="text-xl text-gray-600">아직 공유된 동화책이 없습니다.</p>
-      </div>
-    );
-  }
-
   return (
     <>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
-        {data.pages.map((page, pageIndex) => (
-          <Fragment key={pageIndex}>
-            {page.posts.map((post) => (
-              <LibraryBookCard
-                key={post.postId}
-                post={post}
-              />
-            ))}
-          </Fragment>
-        ))}
+      <div className="w-full grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">
+        {/* Loading Skeleton */}
+        {isLoading &&
+          [...Array(10)].map((_, i) => (
+            <div
+              key={i}
+              className="animate-pulse"
+            >
+              <div className="bg-gray-300 aspect-[3/4] rounded-lg mb-3"></div>
+              <div className="bg-gray-300 h-4 rounded mb-2"></div>
+              <div className="bg-gray-300 h-3 rounded w-2/3"></div>
+            </div>
+          ))}
+
+        {/* Empty State */}
+        {noBooks && (
+          <div className="col-span-full text-center py-20">
+            <p className="text-xl text-gray-600">
+              아직 공유된 동화책이 없습니다.
+            </p>
+          </div>
+        )}
+
+        {/* Book List */}
+        {!isLoading &&
+          !noBooks &&
+          data.pages.map((page, pageIndex) => (
+            <Fragment key={pageIndex}>
+              {page.posts.map((post) => (
+                <LibraryBookCard
+                  key={post.postId}
+                  post={post}
+                />
+              ))}
+            </Fragment>
+          ))}
       </div>
 
       {/* 무한 스크롤 트리거 */}
-      <div
-        ref={ref}
-        className="h-10 mt-8"
-      />
+      {!isLoading && !noBooks && (
+        <div
+          ref={ref}
+          className="h-10 mt-8"
+        />
+      )}
 
+      {/* Loading More */}
       {isFetchingNextPage && (
         <p className="text-center text-gray-600 mt-4">
           더 많은 동화책을 불러오는 중...
         </p>
       )}
 
-      {!hasNextPage && data.pages[0].posts.length > 0 && (
+      {/* All Loaded */}
+      {!hasNextPage && !noBooks && data && data.pages[0].posts.length > 0 && (
         <p className="text-center text-gray-500 mt-4">
           모든 동화책을 불러왔습니다.
         </p>

--- a/src/components/library/library-book-option.ts
+++ b/src/components/library/library-book-option.ts
@@ -1,0 +1,32 @@
+import { ApiResponse, LibraryBookListData } from '@/types/api';
+import { infiniteQueryOptions } from '@tanstack/react-query';
+
+export const libraryBookOption = (sort: string = 'latest') =>
+  infiniteQueryOptions({
+    queryKey: ['library-books', sort],
+    queryFn: async ({ pageParam = 0 }) => {
+      const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/library/posts?page=${pageParam}&size=5&sort=${sort}`;
+      const response = await fetch(backendUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        ...(typeof window === 'undefined' ? { cache: 'no-store' } : {}),
+      });
+
+      if (!response.ok) {
+        throw new Error('책 데이터를 불러올 수 없습니다');
+      }
+
+      const data: ApiResponse<LibraryBookListData> = await response.json();
+      if (!data.data) {
+        throw new Error('책 데이터가 없습니다.');
+      }
+      return data.data;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      return !lastPage.isLast ? lastPage.currentPage + 1 : undefined;
+    },
+    staleTime: 60 * 1000,
+  });

--- a/src/components/library/library-filter.tsx
+++ b/src/components/library/library-filter.tsx
@@ -14,8 +14,9 @@ const LibraryFilter = ({ currentSort }: LibraryFilterProps) => {
 
   const sortOptions = [
     { value: 'latest', label: '최신순' },
-    { value: 'rating', label: '평점순' },
-    { value: 'reviews', label: '리뷰순' },
+    { value: 'popular', label: '인기순' },
+    { value: 'views', label: '조회순' },
+    { value: 'likes', label: '좋아요순' },
   ];
 
   const handleSortChange = (sort: string) => {
@@ -29,7 +30,7 @@ const LibraryFilter = ({ currentSort }: LibraryFilterProps) => {
 
   return (
     <>
-      <div className="bg-white rounded-lg shadow-md p-4 mb-6 flex flex-wrap gap-4 items-center justify-between">
+      <div className="bg-white rounded-lg shadow-md w-full p-4 mb-6 flex flex-wrap gap-4 items-center justify-between">
         <div className="flex gap-3">
           {sortOptions.map((option) => (
             <button

--- a/src/components/mypage/my-book-list.tsx
+++ b/src/components/mypage/my-book-list.tsx
@@ -16,7 +16,7 @@ import { myBookOption } from './my-book-option';
 const MyBookList = () => {
   const queryClient = useQueryClient();
   const { data: session } = useSession();
-  const [currentSort, setCurrentSort] = useState('createdAt,desc');
+  const [currentSort, setCurrentSort] = useState('latest');
 
   const {
     data,
@@ -196,9 +196,9 @@ const MyBookList = () => {
         <h2 className="text-xl font-semibold text-gray-800">내가 만든 책</h2>
         <div className="flex gap-2">
           <button
-            onClick={() => setCurrentSort('createdAt,desc')}
+            onClick={() => setCurrentSort('latest')}
             className={`px-3 py-1 text-sm rounded-full transition-colors ${
-              currentSort === 'createdAt,desc'
+              currentSort === 'latest'
                 ? 'bg-blue-500 text-white'
                 : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
             }`}
@@ -206,9 +206,9 @@ const MyBookList = () => {
             최신순
           </button>
           <button
-            onClick={() => setCurrentSort('createdAt,asc')}
+            onClick={() => setCurrentSort('oldest')}
             className={`px-3 py-1 text-sm rounded-full transition-colors ${
-              currentSort === 'createdAt,asc'
+              currentSort === 'oldest'
                 ? 'bg-blue-500 text-white'
                 : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
             }`}

--- a/src/components/mypage/my-book-list.tsx
+++ b/src/components/mypage/my-book-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ApiResponse, MyBooksData } from '@/types/api';
-import { Fragment, useEffect } from 'react';
+import { ApiResponse, BookStatus, MyBooksData } from '@/types/api';
+import { Fragment, useEffect, useState } from 'react';
 import BookThumbnail from './book-thumbnail';
 import {
   InfiniteData,
@@ -13,38 +13,10 @@ import { useInView } from 'react-intersection-observer';
 import { useSession } from 'next-auth/react';
 import { myBookOption } from './my-book-option';
 
-// API 호출 함수: pageParam을 인자로 받도록 수정
-export const fetchMyBooks = async ({
-  pageParam = 0,
-  accessToken,
-}: {
-  pageParam?: number;
-  accessToken: string;
-}) => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/books/my?status=COMPLETED&page=${pageParam}&size=4`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }
-  );
-  if (!response.ok) {
-    throw new Error('책 데이터를 불러올 수 없습니다.');
-  }
-
-  const data: ApiResponse<MyBooksData> = await response.json();
-  if (!data.data) {
-    throw new Error('책 데이터가 없습니다.');
-  }
-  return data.data;
-};
-
 const MyBookList = () => {
   const queryClient = useQueryClient();
   const { data: session } = useSession();
+  const [currentSort, setCurrentSort] = useState('createdAt,desc');
 
   const {
     data,
@@ -54,7 +26,16 @@ const MyBookList = () => {
     isLoading,
     isError,
     isFetchingNextPage,
-  } = useInfiniteQuery(myBookOption(session?.accessToken));
+  } = useInfiniteQuery({
+    ...myBookOption(session?.accessToken, currentSort),
+    refetchInterval: (query) => {
+      // 현재 데이터에서 PROCESSING 상태의 책이 있는지 확인
+      const hasProcessing = query.state.data?.pages.some((page) =>
+        page.books.some((book) => book.status === BookStatus.PROCESSING)
+      );
+      return hasProcessing ? 10000 : false;
+    },
+  });
 
   const { ref, inView } = useInView({
     threshold: 0.5, // 요소가 50% 보이면 콜백 실행
@@ -211,7 +192,31 @@ const MyBookList = () => {
 
   return (
     <section>
-      <h2 className="text-xl font-semibold mb-4 text-gray-800">내가 만든 책</h2>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-semibold text-gray-800">내가 만든 책</h2>
+        <div className="flex gap-2">
+          <button
+            onClick={() => setCurrentSort('createdAt,desc')}
+            className={`px-3 py-1 text-sm rounded-full transition-colors ${
+              currentSort === 'createdAt,desc'
+                ? 'bg-blue-500 text-white'
+                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+            }`}
+          >
+            최신순
+          </button>
+          <button
+            onClick={() => setCurrentSort('createdAt,asc')}
+            className={`px-3 py-1 text-sm rounded-full transition-colors ${
+              currentSort === 'createdAt,asc'
+                ? 'bg-blue-500 text-white'
+                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+            }`}
+          >
+            오래된순
+          </button>
+        </div>
+      </div>
 
       {!noBookExist ? (
         <>
@@ -225,6 +230,7 @@ const MyBookList = () => {
                     thumbnailUrl={book.thumbnailUrl}
                     title={book.title}
                     isPublic={book.visibility}
+                    status={book.status}
                     onDelete={() => deleteBook({ bookId: book.id })}
                     onStatusChange={handleStatusChange}
                   />

--- a/src/components/mypage/my-book-option.ts
+++ b/src/components/mypage/my-book-option.ts
@@ -1,10 +1,7 @@
 import { ApiResponse, MyBooksData } from '@/types/api';
 import { infiniteQueryOptions } from '@tanstack/react-query';
 
-export const myBookOption = (
-  accessToken?: string,
-  sort: string = 'createdAt,desc'
-) =>
+export const myBookOption = (accessToken?: string, sort: string = 'latest') =>
   infiniteQueryOptions({
     queryKey: ['myBooksInfinite', sort],
     queryFn: async ({ pageParam = 0 }) => {

--- a/src/components/mypage/my-book-option.ts
+++ b/src/components/mypage/my-book-option.ts
@@ -1,11 +1,14 @@
 import { ApiResponse, MyBooksData } from '@/types/api';
 import { infiniteQueryOptions } from '@tanstack/react-query';
 
-export const myBookOption = (accessToken?: string) =>
+export const myBookOption = (
+  accessToken?: string,
+  sort: string = 'createdAt,desc'
+) =>
   infiniteQueryOptions({
-    queryKey: ['myBooksInfinite'],
+    queryKey: ['myBooksInfinite', sort],
     queryFn: async ({ pageParam = 0 }) => {
-      const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/books/my?status=COMPLETED&page=${pageParam}&size=4`;
+      const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/books/my?page=${pageParam}&size=4&sort=${sort}`;
 
       const response = await fetch(backendUrl, {
         method: 'GET',

--- a/src/components/ui/modal/edit-post-modal.tsx
+++ b/src/components/ui/modal/edit-post-modal.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+
+interface EditPostModalProps {
+  initialTitle: string;
+  initialContent: string;
+  onConfirm: (title: string, content: string) => void;
+  onCancel: () => void;
+}
+
+const EditPostModal = ({
+  initialTitle,
+  initialContent,
+  onConfirm,
+  onCancel,
+}: EditPostModalProps) => {
+  const [title, setTitle] = useState(initialTitle);
+  const [content, setContent] = useState(initialContent);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (title.trim() && content.trim()) {
+      onConfirm(title, content);
+    }
+  };
+
+  return (
+    <div className="p-6">
+      <h3 className="text-lg font-bold text-gray-900 mb-4">게시글 수정</h3>
+      <form onSubmit={handleSubmit}>
+        <div className="mb-4">
+          <label
+            htmlFor="title"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            제목
+          </label>
+          <input
+            type="text"
+            id="title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="제목을 입력하세요"
+            required
+          />
+        </div>
+        <div className="mb-6">
+          <label
+            htmlFor="content"
+            className="block text-sm font-medium text-gray-700 mb-2"
+          >
+            내용
+          </label>
+          <textarea
+            id="content"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            rows={6}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+            placeholder="내용을 입력하세요"
+            required
+          />
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            className="flex-1 bg-blue-500 text-white py-2 px-4 rounded-lg hover:bg-blue-600 transition-colors font-semibold"
+          >
+            수정
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 bg-gray-200 text-gray-700 py-2 px-4 rounded-lg hover:bg-gray-300 transition-colors font-semibold"
+          >
+            취소
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};
+
+export default EditPostModal;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -27,7 +27,7 @@ export interface CreateBookPageProps {
 
 export interface CreateBookData {
   bookId: string;
-  status: string;
+  status: BookStatus;
   estimatedCompletionMinutes: string;
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -162,6 +162,18 @@ export interface LibraryDetailBookData {
   reviewCount: number;
 }
 
+export interface PostDetailData {
+  postId: number;
+  bookId: string;
+  title: string;
+  content: string;
+  authorName: string;
+  viewCount: number;
+  likeCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface ReviewListData {
   bookInfo: {
     bookId: string;


### PR DESCRIPTION
## 요약

  책 생성 폼 커스터마이징, 세션 관리 개선, 책 상태별 UI 추가, 정렬 기능 및 레이아웃 일관성 개선

  ### 🎯 주요 기능
  - 책 생성 시 대상 연령(3-12세), 테마(4종), 스타일(4종) 선택 가능
  - 세션 만료 시 자동 로그아웃 기능 구현
  - 책 썸네일에 PROCESSING/FAILED 상태별 UI 표시
  - 마이페이지 책 목록 정렬 기능 (최신순/오래된순)
  - 라이브러리 정렬 옵션 확장 (최신순/인기순/조회순/좋아요순)

  ### 🏗️ 아키텍처 개선
  - React Query option 파일 패턴 도입 (library-book-option.ts)
  - Server-side prefetch 추가로 초기 로딩 속도 개선
  - Query key에 sort 파라미터 포함하여 자동 cache invalidation
  - JWT callback에서 null 반환으로 세션 무효화 처리
  - 조건부 폴링 구현 (refetchInterval as function)

  ### 🎨 UI/UX 개선
  - 책 생성 폼에 range slider로 나이 선택 UI 개선
  - Notification 위치를 버튼 위로 이동하여 가시성 향상
  - PROCESSING 상태 책에 로딩 스피너 표시
  - FAILED 상태 책에 경고 아이콘 표시
  - Grid layout shifting 이슈 수정 (w-full 추가)
  - 라이브러리 페이지 레이아웃 조정 (flex + padding)

  ### 🐛 버그 수정
  - Refresh token 만료 시 반쯤 죽은 세션 상태 문제 해결
  - Grid container width가 아이템 개수에 따라 바뀌는 문제 수정
  - Library book list에서 unique key 경고 수정 (postId 사용)

  ## 테스트 플랜

  - [x] 책 생성 폼에서 나이/테마/스타일 선택 후 정상 생성 확인
  - [x] 책 생성 중 PROCESSING 상태 UI 확인 (로딩 스피너)
  - [x] 10초마다 자동 폴링되는지 확인
  - [x] 책 생성 완료 후 COMPLETED 상태로 변경 확인
  - [x] 마이페이지에서 정렬 버튼 클릭 시 즉시 refetch 확인
  - [x] 라이브러리에서 정렬 옵션 변경 시 URL 업데이트 및 데이터 갱신 확인
  - [x] 세션 만료 후 자동 로그아웃 되는지 확인 (수동 테스트 어려움)
  - [x] Grid layout이 데이터 로딩 중/후에 width 일정하게 유지되는지 확인

  ## 기술적 세부사항

  ### 새로 추가된 파일
  - `src/components/library/library-book-option.ts` - 라이브러리 쿼리 옵션
  - `src/components/ui/modal/edit-post-modal.tsx` - 게시글 수정 모달

  ### 수정된 파일
  - `src/components/book/create-book-form.tsx` - 커스터마이징 옵션 추가
  - `src/auth.ts` - JWT callback null 반환 로직
  - `src/components/layout/auth-button.tsx` - 세션 모니터링 useEffect 추가
  - `src/components/mypage/book-thumbnail.tsx` - 상태별 오버레이 UI
  - `src/components/mypage/my-book-list.tsx` - 정렬 기능 + 조건부 폴링
  - `src/components/mypage/my-book-option.ts` - sort 파라미터 추가
  - `src/components/library/library-book-list.tsx` - Layout shift 수정
  - `src/components/library/library-filter.tsx` - 정렬 옵션 확장
  - `src/app/library/page.tsx` - 레이아웃 조정 및 prefetch
  - `next.config.ts` - via.placeholder.com 도메인 추가

  ### Breaking Changes
  - 없음

  ---

  🤖 Generated with [Claude Code](https://claude.com/claude-code)