### PR TITLE
feat: OAuth 간편 로그인 및 활동 페이지 추가

### DIFF
--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -1,0 +1,49 @@
+import RecentBooks from '@/components/activity/recent-books';
+import BookmarkedPosts from '@/components/activity/bookmarked-posts';
+import MyReviews from '@/components/activity/my-reviews';
+import { getQueryClient } from '@/lib/get-query-client';
+import { auth } from '@/auth';
+import { recentBookOption } from '@/components/activity/recent-books-option';
+import { bookmarkedPostsOption } from '@/components/activity/bookmarked-posts-option';
+import { myReviewsOption } from '@/components/activity/my-reviews-option';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+
+const ActivityPage = async () => {
+  const queryClient = getQueryClient();
+  const session = await auth();
+
+  try {
+    await Promise.all([
+      queryClient.prefetchInfiniteQuery(
+        bookmarkedPostsOption(session?.accessToken)
+      ),
+      queryClient.prefetchQuery(recentBookOption(session?.accessToken)),
+      queryClient.prefetchInfiniteQuery(myReviewsOption(session?.accessToken)),
+    ]);
+  } catch (err) {
+    console.error('activity page prefetch failed', err);
+  }
+
+  const dehydratedState = dehydrate(queryClient);
+
+  return (
+    <main className="max-w-7xl mx-auto p-6 md:p-8 my-8">
+      <div className="mb-8">
+        <h1 className="text-4xl font-bold text-gray-900 mb-3">내 활동</h1>
+        <p className="text-lg text-gray-600">
+          최근 본 책, 북마크한 게시물, 작성한 리뷰를 확인하세요
+        </p>
+      </div>
+
+      <div className="space-y-12">
+        <HydrationBoundary state={dehydratedState}>
+          <RecentBooks />
+          <BookmarkedPosts />
+          <MyReviews />
+        </HydrationBoundary>
+      </div>
+    </main>
+  );
+};
+
+export default ActivityPage;

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -8,35 +8,24 @@ export default function AuthErrorPage() {
   const searchParams = useSearchParams();
   const error = searchParams.get('error');
 
+  const errorMessages: { [key: string]: string } = {
+    Configuration: '서버 설정에 문제가 있습니다',
+    AccessDenied: '접근이 거부되었습니다',
+    Verification: '인증 토큰이 만료되었습니다',
+    OAuthSignin: '소셜 로그인 시작 실패',
+    OAuthCallback: '소셜 로그인 처리 오류',
+    OAuthCreateAccount: '소셜 계정 생성 실패',
+    EmailCreateAccount: '이메일 계정 생성 실패',
+    Callback: '인증 콜백 처리 오류',
+    OAuthAccountNotLinked: '이미 다른 방법으로 가입된 이메일입니다',
+    EmailSignin: '이메일 로그인 실패',
+    CredentialsSignin: '이메일 또는 비밀번호가 올바르지 않습니다',
+    SessionRequired: '로그인이 필요합니다',
+  };
+
   const getErrorMessage = (error: string | null) => {
-    switch (error) {
-      case 'Configuration':
-        return '서버 설정에 문제가 있습니다';
-      case 'AccessDenied':
-        return '접근이 거부되었습니다';
-      case 'Verification':
-        return '인증 토큰이 만료되었습니다';
-      case 'OAuthSignin':
-        return '소셜 로그인 시작 실패';
-      case 'OAuthCallback':
-        return '소셜 로그인 처리 오류';
-      case 'OAuthCreateAccount':
-        return '소셜 계정 생성 실패';
-      case 'EmailCreateAccount':
-        return '이메일 계정 생성 실패';
-      case 'Callback':
-        return '인증 콜백 처리 오류';
-      case 'OAuthAccountNotLinked':
-        return '이미 다른 방법으로 가입된 이메일입니다';
-      case 'EmailSignin':
-        return '이메일 로그인 실패';
-      case 'CredentialsSignin':
-        return '이메일 또는 비밀번호가 올바르지 않습니다';
-      case 'SessionRequired':
-        return '로그인이 필요합니다';
-      default:
-        return '알 수 없는 오류가 발생했습니다';
-    }
+    if (!error) return '알 수 없는 오류가 발생했습니다';
+    return errorMessages[error] || '알 수 없는 오류가 ';
   };
 
   return (

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { FaExclamationTriangle } from 'react-icons/fa';
+
+export default function AuthErrorPage() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get('error');
+
+  const getErrorMessage = (error: string | null) => {
+    switch (error) {
+      case 'Configuration':
+        return '서버 설정에 문제가 있습니다';
+      case 'AccessDenied':
+        return '접근이 거부되었습니다';
+      case 'Verification':
+        return '인증 토큰이 만료되었습니다';
+      case 'OAuthSignin':
+        return '소셜 로그인 시작 실패';
+      case 'OAuthCallback':
+        return '소셜 로그인 처리 오류';
+      case 'OAuthCreateAccount':
+        return '소셜 계정 생성 실패';
+      case 'EmailCreateAccount':
+        return '이메일 계정 생성 실패';
+      case 'Callback':
+        return '인증 콜백 처리 오류';
+      case 'OAuthAccountNotLinked':
+        return '이미 다른 방법으로 가입된 이메일입니다';
+      case 'EmailSignin':
+        return '이메일 로그인 실패';
+      case 'CredentialsSignin':
+        return '이메일 또는 비밀번호가 올바르지 않습니다';
+      case 'SessionRequired':
+        return '로그인이 필요합니다';
+      default:
+        return '알 수 없는 오류가 발생했습니다';
+    }
+  };
+
+  return (
+    <div className="flex w-full items-center justify-center min-h-screen bg-gray-100">
+      <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md">
+        <div className="flex flex-col items-center">
+          <FaExclamationTriangle className="text-red-500 text-6xl mb-4" />
+          <h1 className="text-2xl font-bold text-center text-gray-900 mb-2">
+            로그인 실패
+          </h1>
+          <p className="text-center text-gray-600 mb-6">
+            {getErrorMessage(error)}
+          </p>
+        </div>
+
+        {error && (
+          <div className="bg-gray-50 rounded-lg p-4">
+            <p className="text-sm text-gray-500">
+              <span className="font-semibold">오류 코드:</span> {error}
+            </p>
+          </div>
+        )}
+
+        <div className="space-y-3">
+          <Link
+            href="/auth/login"
+            className="block w-full px-4 py-3 bg-blue-600 text-white text-center font-semibold rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            다시 로그인하기
+          </Link>
+          <Link
+            href="/"
+            className="block w-full px-4 py-3 bg-gray-200 text-gray-700 text-center font-semibold rounded-lg hover:bg-gray-300 transition-colors"
+          >
+            홈으로 돌아가기
+          </Link>
+        </div>
+
+        <p className="text-sm text-center text-gray-600">
+          문제가 계속되면 고객센터로 문의해주세요
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -2,7 +2,7 @@ import LoginForm from '@/components/auth/login-form';
 
 export default function LoginPage() {
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex w-full items-center justify-center min-h-screen bg-gray-100">
       <LoginForm />
     </div>
   );

--- a/src/app/auth/signup/page.tsx
+++ b/src/app/auth/signup/page.tsx
@@ -2,7 +2,7 @@ import SignUpForm from '@/components/auth/signup-form';
 
 export default function LoginPage() {
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
+    <div className="flex items-center justify-center w-full min-h-screen bg-gray-100">
       <SignUpForm />
     </div>
   );

--- a/src/app/books/[slug]/page.tsx
+++ b/src/app/books/[slug]/page.tsx
@@ -2,16 +2,18 @@ import { bookDetailOption } from '@/components/book/book-detail-option';
 import BookFetching from '@/components/book/book-fetching';
 import { getQueryClient } from '@/lib/get-query-client';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
+import { auth } from '@/auth';
 
 // 서버 컴포넌트: 데이터 페칭 담당
 export default async function BookViewerPage(props: {
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await props.params;
+  const session = await auth();
   const queryClient = getQueryClient();
 
   try {
-    await queryClient.prefetchQuery(bookDetailOption(slug));
+    await queryClient.prefetchQuery(bookDetailOption(slug, session?.accessToken));
   } catch (err) {
     console.log('book prefetch failed', err);
   }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
-      <body className="flex flex-col h-screen antialiased">
+      <body className="flex flex-col items-center h-screen antialiased pt-16">
         <AuthProvider session={session}>
           <ReactQueryProvider>
             <Header />

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -27,11 +27,11 @@ export default async function LibraryPage({
   const dehydratedState = dehydrate(queryClient);
 
   return (
-    <main className="flex flex-col items-center py-6 px-40 my-8">
+    <main className="max-w-7xl mx-auto p-6 md:p-8 my-8">
       <div className="w-full mb-6 flex items-end justify-between">
         <div>
           <h1 className="text-4xl font-bold text-gray-900 mb-3">동화 광장</h1>
-          <p className="text-lg text-gray-600">
+          <p className="text-lg text-gray-600 max-md:hidden">
             다양한 사람들이 만든 멋진 동화책을 구경하고, 리뷰를 남겨보세요
           </p>
         </div>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,11 +1,11 @@
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { getQueryClient } from '@/lib/get-query-client';
 import { userProfileOption } from '../../components/mypage/user-profile-option';
-import UserProfile from '../../components/mypage/user-profile';
-import MyBookList from '@/components/mypage/my-book-list';
 import { myBookOption } from '@/components/mypage/my-book-option';
 import { auth } from '@/auth';
 import AccountSettings from '@/components/mypage/account-settings';
+import UserProfile from '@/components/mypage/user-profile';
+import MyBookList from '@/components/mypage/my-book-list';
 
 export default async function MyPage() {
   const queryClient = getQueryClient();
@@ -33,6 +33,7 @@ export default async function MyPage() {
           <UserProfile />
           <MyBookList />
         </HydrationBoundary>
+
         <AccountSettings accessToken={session?.accessToken} />
       </div>
     </main>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,7 +18,7 @@ const SnapSection = ({
 
 export default function HomePage() {
   return (
-    <main className="bg-gray-50 text-gray-800">
+    <main className="bg-gray-50  w-full text-gray-800">
       <SnapSection className="text-center py-20 md:py-32 bg-white">
         <div className="max-w-4xl mx-auto px-4">
           <h1 className="text-4xl md:text-6xl font-extrabold tracking-tight mb-4">

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -118,7 +118,6 @@ export const { handlers, signIn, signOut, unstable_update, auth } = NextAuth({
     async signIn({ user, account }) {
       // OAuth 로그인인 경우
       if (account?.provider === 'google' || account?.provider === 'kakao') {
-        console.log(account.provider, 'login complete', user, account);
         try {
           const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/oauth/simple`;
           const response = await fetch(backendUrl, {
@@ -135,7 +134,6 @@ export const { handlers, signIn, signOut, unstable_update, auth } = NextAuth({
           });
 
           const data: ApiResponse<OAuthData> = await response.json();
-          console.log('OAuth backend response:', data);
 
           if (response.ok && data.data) {
             // 백엔드에서 받은 토큰을 user 객체에 추가

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,6 +1,9 @@
 import NextAuth from 'next-auth';
 import { JWT } from 'next-auth/jwt';
 import Credentials from 'next-auth/providers/credentials';
+import Google from 'next-auth/providers/google';
+import Kakao from 'next-auth/providers/kakao';
+import { ApiResponse, OAuthData } from './types/api';
 
 // Cache for ongoing refresh requests to prevent race conditions
 let refreshPromise: Promise<JWT> | null = null;
@@ -94,6 +97,14 @@ export const { handlers, signIn, signOut, unstable_update, auth } = NextAuth({
         }
       },
     }),
+    Google({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
+    Kakao({
+      clientId: process.env.KAKAO_CLIENT_ID!,
+      clientSecret: process.env.KAKAO_CLIENT_SECRET!,
+    }),
   ],
   session: {
     strategy: 'jwt',
@@ -104,6 +115,47 @@ export const { handlers, signIn, signOut, unstable_update, auth } = NextAuth({
     error: '/auth/error',
   },
   callbacks: {
+    async signIn({ user, account }) {
+      // OAuth 로그인인 경우
+      if (account?.provider === 'google' || account?.provider === 'kakao') {
+        console.log(account.provider, 'login complete', user, account);
+        try {
+          const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/auth/oauth/simple`;
+          const response = await fetch(backendUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              email: user.email,
+              name: user.name,
+              provider: account.provider,
+              providerId: account.providerAccountId,
+            }),
+          });
+
+          const data: ApiResponse<OAuthData> = await response.json();
+          console.log('OAuth backend response:', data);
+
+          if (response.ok && data.data) {
+            // 백엔드에서 받은 토큰을 user 객체에 추가
+            user.accessToken = data.data.accessToken;
+            user.refreshToken = data.data.refreshToken;
+            user.accessTokenExpiresIn = data.data.accessTokenExpiresIn;
+            user.id = data.data.id.toString();
+            return true;
+          }
+
+          return false;
+        } catch (err) {
+          console.error('OAuth backend error:', err);
+          return false;
+        }
+      }
+
+      // Credentials 로그인인 경우
+      return true;
+    },
     async jwt({ token, user }) {
       // 초기 로그인
       if (user) {
@@ -144,6 +196,7 @@ export const { handlers, signIn, signOut, unstable_update, auth } = NextAuth({
     },
     async session({ session, token }) {
       // JWT callback이 null을 반환하면 이 callback은 호출되지 않음
+
       session.user = token.user;
       session.accessToken = token.accessToken;
 

--- a/src/components/activity/bookmarked-posts-option.ts
+++ b/src/components/activity/bookmarked-posts-option.ts
@@ -1,0 +1,42 @@
+import { infiniteQueryOptions } from '@tanstack/react-query';
+import { ApiResponse, MyBookMarkedPostsListData } from '@/types/api';
+
+export const bookmarkedPostsOption = (accessToken?: string) =>
+  infiniteQueryOptions({
+    queryKey: ['bookmarked-posts'],
+    queryFn: async ({ pageParam = 0 }) => {
+      if (!accessToken) {
+        throw new Error('인증 정보가 없습니다.');
+      }
+
+      const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/bookmarks/my?page=${pageParam}`;
+      const response = await fetch(backendUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        // 서버에서는 캐시 사용 안 함
+        ...(typeof window === 'undefined' ? { cache: 'no-store' } : {}),
+      });
+
+      if (!response.ok) {
+        throw new Error('북마크를 불러올 수 없습니다.');
+      }
+
+      const data: ApiResponse<MyBookMarkedPostsListData> =
+        await response.json();
+
+      if (!data.data) {
+        throw new Error('북마크가 없습니다.');
+      }
+      return data.data;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (!lastPage.isLast) {
+        return lastPage.currentPage + 1;
+      }
+    },
+    staleTime: 5 * 60 * 1000, // 5분
+  });

--- a/src/components/activity/bookmarked-posts.tsx
+++ b/src/components/activity/bookmarked-posts.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { FaBookmark, FaStar, FaChevronDown } from 'react-icons/fa';
+import { bookmarkedPostsOption } from './bookmarked-posts-option';
+import { useSession } from 'next-auth/react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { getQueryClient } from '@/lib/get-query-client';
+import { libraryDetailBookOption } from '@/components/library/library-detail-book-option';
+import { formatRelativeTime } from '@/lib/date-utils';
+import { libraryDetailLikeOption } from '../library/library-detail-like-option';
+import { libraryDetailReviewOption } from '../library/library-detail-review-option';
+
+// Section Wrapper 컴포넌트
+const SectionWrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-semibold text-gray-800 flex items-center gap-2">
+          <FaBookmark className="text-yellow-500" />
+          북마크한 게시물
+        </h2>
+        <span className="text-sm text-gray-500">전체 보기</span>
+      </div>
+      {children}
+    </section>
+  );
+};
+
+const BookmarkedPosts = () => {
+  const queryClient = getQueryClient();
+  const { data: session } = useSession();
+  const {
+    data: bookMarkedList,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+    isError,
+    isFetchingNextPage,
+  } = useInfiniteQuery(bookmarkedPostsOption(session?.accessToken));
+
+  const handleMouseEnter = (postId: number) => {
+    queryClient.prefetchQuery(libraryDetailBookOption(postId.toString()));
+    queryClient.prefetchInfiniteQuery(
+      libraryDetailReviewOption(postId.toString())
+    );
+    queryClient.prefetchQuery(
+      libraryDetailLikeOption(postId.toString(), session?.accessToken)
+    );
+  };
+
+  // Loading 상태
+  if (isLoading) {
+    return (
+      <SectionWrapper>
+        <div className="w-full bg-gray-50 rounded-lg p-12 text-center opacity-60 animate-pulse">
+          <FaBookmark className="mx-auto text-gray-300 text-5xl mb-4" />
+          <p className="text-gray-500 text-lg">불러오는 중...</p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  // Error 상태
+  if (isError) {
+    return (
+      <SectionWrapper>
+        <div className="bg-red-50 rounded-lg p-12 text-center">
+          <p className="text-red-500 text-lg">
+            {error instanceof Error
+              ? error.message
+              : '데이터를 불러올 수 없습니다'}
+          </p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  const bookmarks =
+    bookMarkedList?.pages.flatMap((page) => page.bookmarks) || [];
+
+  // Empty 상태
+  if (bookmarks.length === 0) {
+    return (
+      <SectionWrapper>
+        <div className="bg-gray-50 rounded-lg p-12 text-center">
+          <FaBookmark className="mx-auto text-gray-300 text-5xl mb-4" />
+          <p className="text-gray-500 text-lg">
+            아직 북마크한 게시물이 없습니다
+          </p>
+          <p className="text-gray-400 text-sm mt-2">
+            마음에 드는 게시물을 북마크해보세요
+          </p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  // Data 렌더링
+  return (
+    <SectionWrapper>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
+        {bookmarks.map((bookmark, i) => (
+          <Link
+            key={(bookmark.bookMarkId, i)}
+            href={`/library/${bookmark.postId}`}
+            onMouseEnter={() => handleMouseEnter(bookmark.postId)}
+            className="bg-white rounded-lg shadow-md p-5 hover:shadow-lg transition-shadow border border-gray-100"
+          >
+            <div className="flex gap-4">
+              <div className="relative w-24 h-32 rounded-lg flex-shrink-0 overflow-hidden bg-gray-100">
+                <Image
+                  src={bookmark.thumbnailUrl}
+                  alt={bookmark.postTitle}
+                  fill
+                  className="object-cover"
+                  sizes="96px"
+                />
+              </div>
+              <div className="flex-1">
+                <h3 className="font-semibold text-gray-800 mb-2 line-clamp-2">
+                  {bookmark.postTitle}
+                </h3>
+                <div className="flex items-center gap-2 mb-2">
+                  <FaStar className="text-yellow-400 text-sm" />
+                  <span className="text-sm text-gray-700">
+                    {bookmark.post.averageRating
+                      ? bookmark.post.averageRating.toFixed(1)
+                      : '0.0'}
+                  </span>
+                  <span className="text-xs text-gray-500">
+                    ({bookmark.post.reviewCount})
+                  </span>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-gray-500">
+                  <span>{bookmark.post.authorName}</span>
+                  <span>•</span>
+                  <span>{formatRelativeTime(bookmark.bookMarkedAt)}</span>
+                </div>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+      {hasNextPage && (
+        <div className="flex justify-center mt-6">
+          <button
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+            className="flex items-center gap-2 text-gray-600 hover:text-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isFetchingNextPage ? '로딩 중...' : '더 보기'}
+            {!isFetchingNextPage && <FaChevronDown className="text-sm" />}
+          </button>
+        </div>
+      )}
+    </SectionWrapper>
+  );
+};
+
+export default BookmarkedPosts;

--- a/src/components/activity/bookmarked-posts.tsx
+++ b/src/components/activity/bookmarked-posts.tsx
@@ -102,9 +102,9 @@ const BookmarkedPosts = () => {
   return (
     <SectionWrapper>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
-        {bookmarks.map((bookmark, i) => (
+        {bookmarks.map((bookmark) => (
           <Link
-            key={(bookmark.bookMarkId, i)}
+            key={bookmark.bookMarkId}
             href={`/library/${bookmark.postId}`}
             onMouseEnter={() => handleMouseEnter(bookmark.postId)}
             className="bg-white rounded-lg shadow-md p-5 hover:shadow-lg transition-shadow border border-gray-100"

--- a/src/components/activity/my-reviews-option.ts
+++ b/src/components/activity/my-reviews-option.ts
@@ -1,0 +1,41 @@
+import { infiniteQueryOptions } from '@tanstack/react-query';
+import { ApiResponse, MyReviewsListData } from '@/types/api';
+
+export const myReviewsOption = (accessToken?: string) =>
+  infiniteQueryOptions({
+    queryKey: ['my-reviews'],
+    queryFn: async ({ pageParam = 0 }) => {
+      if (!accessToken) {
+        throw new Error('인증 정보가 없습니다.');
+      }
+
+      const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/reviews/my?page=${pageParam}`;
+      const response = await fetch(backendUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        // 서버에서는 캐시 사용 안 함
+        ...(typeof window === 'undefined' ? { cache: 'no-store' } : {}),
+      });
+
+      if (!response.ok) {
+        throw new Error('리뷰를 불러올 수 없습니다.');
+      }
+
+      const data: ApiResponse<MyReviewsListData> = await response.json();
+
+      if (!data.data) {
+        throw new Error('리뷰가 없습니다.');
+      }
+      return data.data;
+    },
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      if (lastPage.number !== lastPage.totalPages) {
+        return lastPage.number + 1;
+      }
+    },
+    staleTime: 5 * 60 * 1000, // 5분
+  });

--- a/src/components/activity/my-reviews-option.ts
+++ b/src/components/activity/my-reviews-option.ts
@@ -33,8 +33,8 @@ export const myReviewsOption = (accessToken?: string) =>
     },
     initialPageParam: 0,
     getNextPageParam: (lastPage) => {
-      if (lastPage.number !== lastPage.totalPages) {
-        return lastPage.number + 1;
+      if (!lastPage.isLast) {
+        return lastPage.currentPage + 1;
       }
     },
     staleTime: 5 * 60 * 1000, // 5분

--- a/src/components/activity/my-reviews.tsx
+++ b/src/components/activity/my-reviews.tsx
@@ -77,7 +77,7 @@ export default function MyReviews() {
     );
   }
 
-  const reviews = myReviewsList?.pages.flatMap((page) => page.content) || [];
+  const reviews = myReviewsList?.pages.flatMap((page) => page.reviews) || [];
 
   // Empty 상태
   if (reviews.length === 0) {

--- a/src/components/activity/my-reviews.tsx
+++ b/src/components/activity/my-reviews.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { FaStar, FaBook, FaChevronDown } from 'react-icons/fa';
+import { myReviewsOption } from './my-reviews-option';
+import Link from 'next/link';
+import { getQueryClient } from '@/lib/get-query-client';
+import { libraryDetailBookOption } from '@/components/library/library-detail-book-option';
+import { formatRelativeTime } from '@/lib/date-utils';
+import { libraryDetailReviewOption } from '../library/library-detail-review-option';
+import { libraryDetailLikeOption } from '../library/library-detail-like-option';
+
+// Section Wrapper 컴포넌트
+const SectionWrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <section className="w-full">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-semibold text-gray-800 flex items-center gap-2">
+          <FaStar className="text-yellow-400" />
+          내가 쓴 리뷰
+        </h2>
+        <span className="text-sm text-gray-500">전체 보기</span>
+      </div>
+      {children}
+    </section>
+  );
+};
+
+export default function MyReviews() {
+  const queryClient = getQueryClient();
+  const { data: session } = useSession();
+  const {
+    data: myReviewsList,
+    error,
+    fetchNextPage,
+    hasNextPage,
+    isLoading,
+    isError,
+    isFetchingNextPage,
+  } = useInfiniteQuery(myReviewsOption(session?.accessToken));
+
+  const handleMouseEnter = (postId: number) => {
+    queryClient.prefetchQuery(libraryDetailBookOption(postId.toString()));
+    queryClient.prefetchInfiniteQuery(
+      libraryDetailReviewOption(postId.toString())
+    );
+    queryClient.prefetchQuery(
+      libraryDetailLikeOption(postId.toString(), session?.accessToken)
+    );
+  };
+
+  // Loading 상태
+  if (isLoading) {
+    return (
+      <SectionWrapper>
+        <div className="w-full bg-gray-50 rounded-lg p-12 text-center opacity-60 animate-pulse">
+          <FaStar className="mx-auto text-gray-300 text-5xl mb-4" />
+          <p className="text-gray-500 text-lg">불러오는 중...</p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  // Error 상태
+  if (isError) {
+    return (
+      <SectionWrapper>
+        <div className="bg-red-50 rounded-lg p-12 text-center">
+          <p className="text-red-500 text-lg">
+            {error instanceof Error
+              ? error.message
+              : '데이터를 불러올 수 없습니다'}
+          </p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  const reviews = myReviewsList?.pages.flatMap((page) => page.content) || [];
+
+  // Empty 상태
+  if (reviews.length === 0) {
+    return (
+      <SectionWrapper>
+        <div className="bg-gray-50 rounded-lg p-12 text-center">
+          <FaStar className="mx-auto text-gray-300 text-5xl mb-4" />
+          <p className="text-gray-500 text-lg">아직 작성한 리뷰가 없습니다</p>
+          <p className="text-gray-400 text-sm mt-2">
+            읽은 책에 대한 리뷰를 남겨보세요
+          </p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  // Data 렌더링
+  return (
+    <SectionWrapper>
+      <div className="space-y-4 w-full">
+        {reviews.map((review) => (
+          <Link
+            key={review.reviewId}
+            href={`/library/${review.postId}`}
+            onMouseEnter={() => handleMouseEnter(review.postId)}
+            className="bg-white rounded-lg shadow-md p-5 hover:shadow-lg transition-shadow border border-gray-100 block"
+          >
+            <div className="flex items-start gap-4">
+              <div className="bg-blue-50 w-16 h-20 rounded flex-shrink-0 flex items-center justify-center">
+                <FaBook className="text-blue-400 text-2xl" />
+              </div>
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-2">
+                  <h3 className="font-semibold text-gray-800">
+                    {review.bookTitle}
+                  </h3>
+                  <div className="flex gap-1">
+                    {[...Array(5)].map((_, starIdx) => (
+                      <FaStar
+                        key={starIdx}
+                        className={`text-sm ${
+                          starIdx < review.rating
+                            ? 'text-yellow-400'
+                            : 'text-gray-300'
+                        }`}
+                      />
+                    ))}
+                  </div>
+                </div>
+                <p className="text-gray-600 text-sm line-clamp-2 mb-2">
+                  {review.comment}
+                </p>
+                <span className="text-xs text-gray-500">
+                  {formatRelativeTime(review.createdAt)} 작성
+                </span>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+      {hasNextPage && (
+        <div className="flex justify-center mt-6">
+          <button
+            onClick={() => fetchNextPage()}
+            disabled={isFetchingNextPage}
+            className="flex items-center gap-2 text-gray-600 hover:text-gray-900 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isFetchingNextPage ? '로딩 중...' : '더 보기'}
+            {!isFetchingNextPage && <FaChevronDown className="text-sm" />}
+          </button>
+        </div>
+      )}
+    </SectionWrapper>
+  );
+}

--- a/src/components/activity/recent-books-option.ts
+++ b/src/components/activity/recent-books-option.ts
@@ -1,0 +1,36 @@
+import { queryOptions } from '@tanstack/react-query';
+import { ApiResponse, RecentBooksData } from '@/types/api';
+
+export const recentBookOption = (accessToken?: string) =>
+  queryOptions({
+    queryKey: ['recent-book'],
+    queryFn: async () => {
+      if (!accessToken) {
+        throw new Error('인증 정보가 없습니다.');
+      }
+
+      const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/books/recent`;
+      const response = await fetch(backendUrl, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        // 서버에서는 캐시 사용 안 함
+        ...(typeof window === 'undefined' ? { cache: 'no-store' } : {}),
+      });
+
+      if (!response.ok) {
+        throw new Error('기록을 불러올 수 없습니다.');
+      }
+
+      const data: ApiResponse<RecentBooksData[]> = await response.json();
+
+      if (data?.code === 'BOOK_2008' && data.data) {
+        return data.data;
+      }
+
+      throw new Error(data?.message || '최근에 본 책을 찾을 수 없습니다.');
+    },
+    staleTime: 5 * 60 * 1000, // 5분
+  });

--- a/src/components/activity/recent-books.tsx
+++ b/src/components/activity/recent-books.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { FaBook } from 'react-icons/fa';
+import { recentBookOption } from './recent-books-option';
+import { useSession } from 'next-auth/react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { getQueryClient } from '@/lib/get-query-client';
+import { bookDetailOption } from '../book/book-detail-option';
+import { formatRelativeTime } from '@/lib/date-utils';
+import { useEffect } from 'react';
+
+const SectionWrapper = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-2xl font-semibold text-gray-800 flex items-center gap-2">
+          <FaBook className="text-blue-600" />
+          최근 본 책
+        </h2>
+        <span className="text-sm text-gray-500">최근 10개</span>
+      </div>
+      {children}
+    </section>
+  );
+};
+
+const RecentBooks = () => {
+  const queryClient = getQueryClient();
+  const { data: session } = useSession();
+  const {
+    data: recentBooks,
+    isLoading,
+    isError,
+    error,
+  } = useQuery(recentBookOption(session?.accessToken));
+
+  useEffect(() => {
+    queryClient.invalidateQueries({ queryKey: ['recent-book'] });
+  }, [queryClient]);
+
+  const handleMouseEnter = (bookId: string) => {
+    queryClient.prefetchQuery(bookDetailOption(bookId));
+  };
+
+  if (isLoading) {
+    return (
+      <SectionWrapper>
+        <div className="w-full bg-gray-50 rounded-lg p-12 text-center opacity-60 animate-pulse">
+          <FaBook className="mx-auto text-gray-300 text-5xl mb-4" />
+          <p className="text-gray-500 text-lg">불러오는 중...</p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  if (isError) {
+    return (
+      <SectionWrapper>
+        <div className="bg-red-50 rounded-lg p-12 text-center">
+          <p className="text-red-500 text-lg">
+            {error instanceof Error
+              ? error.message
+              : '데이터를 불러올 수 없습니다'}
+          </p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  if (!recentBooks || recentBooks.length === 0) {
+    return (
+      <SectionWrapper>
+        <div className="bg-gray-50 rounded-lg p-12 text-center">
+          <FaBook className="mx-auto text-gray-300 text-5xl mb-4" />
+          <p className="text-gray-500 text-lg">아직 본 책이 없습니다</p>
+          <p className="text-gray-400 text-sm mt-2">
+            동화책을 읽으면 여기에 기록됩니다
+          </p>
+        </div>
+      </SectionWrapper>
+    );
+  }
+
+  return (
+    <SectionWrapper>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6 w-full">
+        {recentBooks.map((book) => (
+          <Link
+            key={book.bookId}
+            href={`/books/${book.bookId}`}
+            onMouseEnter={() => handleMouseEnter(book.bookId)}
+            onClick={() => {
+              queryClient.invalidateQueries({ queryKey: ['recent-book'] });
+            }}
+            className="bg-white rounded-lg p-4 transition-shadow"
+          >
+            <div className="relative aspect-[3/4] rounded-lg mb-3 overflow-hidden hover:shadow-lg bg-gray-100">
+              <Image
+                src={book.thumbnailUrl}
+                alt={book.title}
+                fill
+                className="object-cover"
+                sizes="(max-width: 640px) 50vw, (max-width: 768px) 33vw, (max-width: 1024px) 25vw, 20vw"
+              />
+            </div>
+            <h3
+              className="font-medium text-gray-800 truncate"
+              title={book.title}
+            >
+              {book.title}
+            </h3>
+            <p className="text-sm text-gray-500">
+              {formatRelativeTime(book.viewedAt)}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </SectionWrapper>
+  );
+};
+
+export default RecentBooks;

--- a/src/components/activity/recent-books.tsx
+++ b/src/components/activity/recent-books.tsx
@@ -9,7 +9,6 @@ import Link from 'next/link';
 import { getQueryClient } from '@/lib/get-query-client';
 import { bookDetailOption } from '../book/book-detail-option';
 import { formatRelativeTime } from '@/lib/date-utils';
-import { useEffect } from 'react';
 
 const SectionWrapper = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -35,10 +34,6 @@ const RecentBooks = () => {
     isError,
     error,
   } = useQuery(recentBookOption(session?.accessToken));
-
-  useEffect(() => {
-    queryClient.invalidateQueries({ queryKey: ['recent-book'] });
-  }, [queryClient]);
 
   const handleMouseEnter = (bookId: string) => {
     queryClient.prefetchQuery(bookDetailOption(bookId));
@@ -92,7 +87,7 @@ const RecentBooks = () => {
             href={`/books/${book.bookId}`}
             onMouseEnter={() => handleMouseEnter(book.bookId)}
             onClick={() => {
-              queryClient.invalidateQueries({ queryKey: ['recent-book'] });
+              queryClient.fetchQuery({ queryKey: ['recent-book'] });
             }}
             className="bg-white rounded-lg p-4 transition-shadow"
           >

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -4,8 +4,10 @@ import { useFormStatus } from 'react-dom';
 import { loginAction } from '@/lib/server-action';
 import Link from 'next/link';
 import { useActionState, useEffect } from 'react';
-import { useSession } from 'next-auth/react';
+import { useSession, signIn } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import { RiKakaoTalkFill } from 'react-icons/ri';
+import { FcGoogle } from 'react-icons/fc';
 
 // 제출 버튼을 위한 별도 컴포넌트 (useFormStatus 훅 사용)
 function LoginButton() {
@@ -39,9 +41,49 @@ export default function LoginForm() {
 
   const errorMessage = message && message !== 'SUCCESS' ? message : undefined;
 
+  const handleGoogleLogin = () => {
+    signIn('google', { callbackUrl: '/mypage' });
+  };
+
+  const handleKakaoLogin = () => {
+    signIn('kakao', { callbackUrl: '/mypage' });
+  };
+
   return (
     <div className="w-full max-w-md p-8 space-y-6 bg-white rounded-lg shadow-md">
       <h1 className="text-2xl font-bold text-center">로그인</h1>
+
+      {/* 소셜 로그인 */}
+      <div className="space-y-3">
+        <button
+          onClick={handleGoogleLogin}
+          type="button"
+          className="w-full flex items-center justify-center gap-2 px-4 py-3 border border-gray-300 rounded-md shadow-sm bg-white hover:bg-gray-50 transition-colors"
+        >
+          <FcGoogle className="text-xl" />
+          <span className="font-medium text-gray-700">Google로 로그인</span>
+        </button>
+        <button
+          onClick={handleKakaoLogin}
+          type="button"
+          className="w-full flex items-center justify-center gap-3 px-4 py-3 rounded-md shadow-sm bg-[#FEE500] hover:bg-[#FDD835] transition-colors"
+        >
+          <RiKakaoTalkFill className="text-[#3C1E1E] text-2xl" />
+          <span className="font-medium text-[#3C1E1E]">카카오로 로그인</span>
+        </button>
+      </div>
+
+      {/* 구분선 */}
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-gray-300"></div>
+        </div>
+        <div className="relative flex justify-center text-sm">
+          <span className="px-2 bg-white text-gray-500">또는</span>
+        </div>
+      </div>
+
+      {/* 이메일 로그인 */}
       <form
         action={dispatch}
         className="space-y-6"

--- a/src/components/book/book-detail-option.ts
+++ b/src/components/book/book-detail-option.ts
@@ -1,13 +1,10 @@
-// components/book/book-detail-option.ts
-import { auth } from '@/auth';
 import { queryOptions } from '@tanstack/react-query';
 import { ApiResponse, BookData } from '@/types/api';
 
-export const bookDetailOption = (slug: string) =>
+export const bookDetailOption = (slug: string, accessToken?: string) =>
   queryOptions({
     queryKey: ['book-detail', slug],
     queryFn: async () => {
-      const session = await auth();
       const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/books/${slug}`;
 
       const response = await fetch(backendUrl, {
@@ -15,8 +12,8 @@ export const bookDetailOption = (slug: string) =>
         headers: {
           'Content-Type': 'application/json',
           // 인증이 필요한 경우에만 헤더 추가
-          ...(session?.accessToken && {
-            Authorization: `Bearer ${session.accessToken}`,
+          ...(accessToken && {
+            Authorization: `Bearer ${accessToken}`,
           }),
         },
         // 서버에서는 캐시 사용 안 함
@@ -31,6 +28,10 @@ export const bookDetailOption = (slug: string) =>
 
       if (data?.code === 'BOOK_2002' && data.data) {
         return data.data;
+      }
+
+      if (data.code === 'BOOK_4005') {
+        throw new Error(data.message || '열람할 수 없는 책입니다.');
       }
 
       throw new Error(data?.message || '책을 찾을 수 없습니다.');

--- a/src/components/book/book-fetching.tsx
+++ b/src/components/book/book-fetching.tsx
@@ -1,41 +1,9 @@
 'use client';
 
-import { ApiResponse, BookData } from '@/types/api';
-import BookDisplay from './book-display'; // 실제 UI 컴포넌트
+import BookDisplay from './book-display';
 import { useSession } from 'next-auth/react';
 import { useQuery } from '@tanstack/react-query';
-
-const fetchBookDetail = async (slug: string, accessToken?: string) => {
-  const response = await fetch(
-    `${process.env.NEXT_PUBLIC_API_URL}/api/v1/books/${slug}`,
-    {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-        // 인증이 필요한 경우에만 헤더 추가
-        ...(accessToken && {
-          Authorization: `Bearer ${accessToken}`,
-        }),
-      },
-    }
-  );
-
-  if (!response.ok) {
-    throw new Error('책을 불러올 수 없습니다.');
-  }
-
-  const data: ApiResponse<BookData> = await response.json();
-
-  if (data.code === 'BOOK_4005') {
-    throw new Error(data.message || '열람할 수 없는 책입니다.');
-  }
-
-  if (data?.code === 'BOOK_2002' && data.data) {
-    return data.data;
-  }
-
-  throw new Error(data?.message || '책을 찾을 수 없습니다.');
-};
+import { bookDetailOption } from './book-detail-option';
 
 export default function BookFetching({ slug }: { slug: string }) {
   const { data: session } = useSession();
@@ -44,10 +12,7 @@ export default function BookFetching({ slug }: { slug: string }) {
     data: bookData,
     isLoading,
     error,
-  } = useQuery({
-    queryKey: ['book-detail', slug],
-    queryFn: () => fetchBookDetail(slug, session?.accessToken),
-  });
+  } = useQuery(bookDetailOption(slug, session?.accessToken));
 
   if (isLoading) return <div>책을 불러오는 중...</div>;
   if (!bookData) return <div>해당 책을 찾을 수 없습니다.</div>;

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
     'text-gray-500 transition-colors duration-200 hover:text-blue-500 hover:underline';
 
   return (
-    <footer className="bg-gray-50 border-t border-gray-200 text-sm text-gray-500">
+    <footer className="w-full bg-gray-50 border-t border-gray-200 text-sm text-gray-500">
       <div className="max-w-6xl mx-auto py-16 px-8">
         <div className="flex flex-wrap justify-between gap-8 mb-12">
           {/* --- 프로젝트 섹션 --- */}

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -10,7 +10,7 @@ export default async function Header() {
 
   return (
     <ScrollHeader>
-      <header className="sticky top-0 bg-white bg-opacity-80 backdrop-blur-sm border-b border-gray-200 z-50">
+      <header className="bg-white bg-opacity-80 backdrop-blur-sm border-b border-gray-200">
         <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between h-16">
             {/* 로고 및 사이트 이름 */}

--- a/src/components/layout/navigation.tsx
+++ b/src/components/layout/navigation.tsx
@@ -7,6 +7,7 @@ const navLinks = [
   { href: '/', label: 'Home' },
   { href: '/books', label: '동화책 만들기' },
   { href: '/library', label: '모두의 서재' },
+  { href: '/activity', label: '내 활동' },
   { href: '/mypage', label: '마이페이지' },
 ];
 

--- a/src/components/layout/scroll-header.tsx
+++ b/src/components/layout/scroll-header.tsx
@@ -33,7 +33,7 @@ export default function ScrollHeader({ children }: ScrollHeaderProps) {
 
   return (
     <div
-      className={`transition-transform duration-300 ${
+      className={`fixed top-0 w-full left-0 z-50 transition-transform duration-300 ${
         isVisible ? 'translate-y-0' : '-translate-y-full'
       }`}
     >

--- a/src/components/library/book-detail-info.tsx
+++ b/src/components/library/book-detail-info.tsx
@@ -281,7 +281,9 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
   if (!postData) return <p>책을 찾을 수 없습니다.</p>;
 
   const handleMouseEnter = () => {
-    queryClient.prefetchQuery(bookDetailOption(postData.book.bookId));
+    queryClient.prefetchQuery(
+      bookDetailOption(postData.book.bookId, session?.accessToken)
+    );
   };
 
   const handleLike = async () => {
@@ -344,7 +346,10 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
   const isAuthor = user && postData && user.id === postData.authorId;
 
   return (
-    <div className="bg-white rounded-lg shadow-lg p-6 md:p-8">
+    <div
+      onMouseEnter={handleMouseEnter}
+      className="bg-white rounded-lg shadow-lg p-6 md:p-8"
+    >
       <div className="flex flex-col md:flex-row gap-8">
         {/* 왼쪽: 책 표지 */}
         <div className="w-full md:w-1/4 flex-shrink-0">
@@ -361,7 +366,6 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
           {/* 읽기 버튼 */}
           <Link
             href={`/books/${postData.book.bookId}`}
-            onMouseEnter={handleMouseEnter}
             className="mt-4 w-full block text-center bg-blue-600 text-white font-bold py-3 rounded-lg hover:bg-blue-700 transition-colors"
           >
             동화책 읽기 📖

--- a/src/components/library/book-reviews.tsx
+++ b/src/components/library/book-reviews.tsx
@@ -1,4 +1,3 @@
-// components/community/book-reviews.tsx
 'use client';
 
 import { useEffect, useState } from 'react';
@@ -211,12 +210,13 @@ export default function BookReviews({ slug }: BookReviewsProps) {
   if (isError) return <p>오류가 발생했습니다: {error.message}</p>;
 
   const allReviews = reviews?.pages.flatMap((page) => page.reviews) || [];
+  const totalReviews = reviews?.pages[0].pageInfo.totalElements || 0;
 
   return (
     <div className="bg-white rounded-lg shadow-lg p-6 md:p-8">
       <div className="flex items-center justify-between mb-6">
         <h2 className="text-2xl font-bold text-gray-900">
-          리뷰 ({allReviews.length})
+          리뷰 ({totalReviews})
         </h2>
 
         {!isWriting && session && (

--- a/src/components/library/library-filter.tsx
+++ b/src/components/library/library-filter.tsx
@@ -31,13 +31,13 @@ const LibraryFilter = ({ currentSort }: LibraryFilterProps) => {
   return (
     <>
       <div className="bg-white rounded-lg shadow-md w-full p-4 mb-6 flex flex-wrap gap-4 items-center justify-between">
-        <div className="flex gap-3">
+        <div className="flex flew-row gap-3">
           {sortOptions.map((option) => (
             <button
               key={option.value}
               onClick={() => handleSortChange(option.value)}
               disabled={isPending}
-              className={`px-4 py-2 rounded-lg transition-colors font-medium ${
+              className={`px-4 py-2 max-md:text-xs rounded-lg transition-colors font-medium ${
                 currentSort === option.value
                   ? 'bg-blue-500 text-white hover:bg-blue-600'
                   : 'bg-gray-200 text-gray-700 hover:bg-gray-300'

--- a/src/components/library/library-filter.tsx
+++ b/src/components/library/library-filter.tsx
@@ -31,7 +31,7 @@ const LibraryFilter = ({ currentSort }: LibraryFilterProps) => {
   return (
     <>
       <div className="bg-white rounded-lg shadow-md w-full p-4 mb-6 flex flex-wrap gap-4 items-center justify-between">
-        <div className="flex flew-row gap-3">
+        <div className="flex flex-row gap-3">
           {sortOptions.map((option) => (
             <button
               key={option.value}

--- a/src/components/mypage/book-thumbnail.tsx
+++ b/src/components/mypage/book-thumbnail.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { getQueryClient } from '@/lib/get-query-client';
-import { ApiResponse, BookData, BookStatus } from '@/types/api';
+import { BookStatus } from '@/types/api';
 import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { useState } from 'react';
@@ -9,6 +9,7 @@ import { FaTrash } from 'react-icons/fa';
 import useModalStore from '@/store/use-modal-store';
 import MyBookDeleteModal from '@/components/ui/modal/mybook-delete-modal';
 import Image from 'next/image';
+import { bookDetailOption } from '../book/book-detail-option';
 
 interface BookThumbnailProps {
   id: string;
@@ -40,31 +41,7 @@ const BookThumbnail = ({
 
   const handleMouseEnter = () => {
     if (session?.accessToken) {
-      queryClient.prefetchQuery({
-        queryKey: ['book-detail', id],
-        queryFn: async () => {
-          const response = await fetch(
-            `${process.env.NEXT_PUBLIC_API_URL}/api/v1/books/${id}`,
-            {
-              headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${session.accessToken}`,
-              },
-            }
-          );
-
-          if (!response.ok) {
-            throw new Error('Failed to fetch book');
-          }
-
-          const data: ApiResponse<BookData> = await response.json();
-          if (data?.code === 'BOOK_2002' && data.data) {
-            return data.data;
-          }
-          throw new Error(data?.message || '책을 찾을 수 없습니다.');
-        },
-        staleTime: 5 * 60 * 1000,
-      });
+      queryClient.prefetchQuery(bookDetailOption(id));
     }
   };
 

--- a/src/components/ui/modal/phone-number-modal.tsx
+++ b/src/components/ui/modal/phone-number-modal.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react';
 import { UserProfileData } from '@/types/api';
 import useModalStore from '@/store/use-modal-store';
 import useUserStore from '@/store/use-user-store';
+import { formatPhoneNumber, validatePhoneNumber } from '@/lib/phone-utils';
 
 interface PhoneNumberModalProps {
   onConfirm: () => void;
@@ -79,21 +80,6 @@ const PhoneNumberModal = ({ onConfirm }: PhoneNumberModalProps) => {
     },
   });
 
-  const formatPhoneNumber = (value: string) => {
-    const numbers = value.replace(/\D/g, '');
-
-    if (numbers.length <= 3) {
-      return numbers;
-    } else if (numbers.length <= 7) {
-      return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
-    } else {
-      return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(
-        7,
-        11
-      )}`;
-    }
-  };
-
   const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const formatted = formatPhoneNumber(e.target.value);
     setPhoneNumber(formatted);
@@ -119,8 +105,7 @@ const PhoneNumberModal = ({ onConfirm }: PhoneNumberModalProps) => {
       return;
     }
 
-    const phoneRegex = /^01[0-9]-?[0-9]{3,4}-?[0-9]{4}$/;
-    if (!phoneRegex.test(phoneNumber.trim())) {
+    if (!validatePhoneNumber(phoneNumber)) {
       alert('올바른 전화번호 형식이 아닙니다. (예: 010-1234-5678)');
       return;
     }

--- a/src/components/ui/modal/phone-number-modal.tsx
+++ b/src/components/ui/modal/phone-number-modal.tsx
@@ -1,0 +1,193 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useSession } from 'next-auth/react';
+import { UserProfileData } from '@/types/api';
+import useModalStore from '@/store/use-modal-store';
+import useUserStore from '@/store/use-user-store';
+
+interface PhoneNumberModalProps {
+  onConfirm: () => void;
+}
+
+const PhoneNumberModal = ({ onConfirm }: PhoneNumberModalProps) => {
+  const { data: session, update } = useSession();
+  const { closeModal } = useModalStore();
+  const { updateUserPhoneNumber } = useUserStore();
+  const queryClient = useQueryClient();
+  const [name, setName] = useState(session?.user?.name || '');
+  const [phoneNumber, setPhoneNumber] = useState('');
+
+  const { mutate: updateProfile, isPending } = useMutation({
+    mutationFn: async ({
+      name,
+      phoneNumber,
+    }: {
+      name: string;
+      phoneNumber: string;
+    }) => {
+      if (!session?.accessToken) {
+        throw new Error('인증 정보가 없습니다.');
+      }
+
+      const backendUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/v1/members/me`;
+      const response = await fetch(backendUrl, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session?.accessToken}`,
+        },
+        body: JSON.stringify({ name, phoneNumber }),
+      });
+
+      if (!response.ok) {
+        throw new Error('프로필 업데이트에 실패했습니다.');
+      }
+
+      const data = await response.json();
+      return data.data;
+    },
+    onMutate: async () => {
+      await queryClient.cancelQueries({
+        queryKey: ['members-me'],
+      });
+      const previousUser = queryClient.getQueryData<UserProfileData>([
+        'members-me',
+      ]);
+      queryClient.setQueryData<UserProfileData>(['members-me'], (old) => {
+        if (!old) return old;
+        return { ...old, name, phoneNumber };
+      });
+
+      return { previousUser };
+    },
+    onError: (err) => {
+      console.error('프로필 업데이트 실패:', err);
+      alert('프로필 업데이트에 실패했습니다. 다시 시도해주세요.');
+    },
+    onSuccess: () => {
+      updateUserPhoneNumber(phoneNumber);
+      alert('프로필 업데이트 성공!');
+    },
+    onSettled: async () => {
+      queryClient.invalidateQueries({
+        queryKey: ['members-me'],
+      });
+      await update({ isNewUser: false });
+      closeModal();
+    },
+  });
+
+  const formatPhoneNumber = (value: string) => {
+    const numbers = value.replace(/\D/g, '');
+
+    if (numbers.length <= 3) {
+      return numbers;
+    } else if (numbers.length <= 7) {
+      return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
+    } else {
+      return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(
+        7,
+        11
+      )}`;
+    }
+  };
+
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const formatted = formatPhoneNumber(e.target.value);
+    setPhoneNumber(formatted);
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    // Validate name
+    if (!name.trim()) {
+      alert('이름을 입력해주세요.');
+      return;
+    }
+
+    if (name.trim().length < 2 || name.trim().length > 20) {
+      alert('이름은 2자 이상 20자 이하로 입력해주세요.');
+      return;
+    }
+
+    // Validate phone number
+    if (!phoneNumber.trim()) {
+      alert('전화번호를 입력해주세요.');
+      return;
+    }
+
+    const phoneRegex = /^01[0-9]-?[0-9]{3,4}-?[0-9]{4}$/;
+    if (!phoneRegex.test(phoneNumber.trim())) {
+      alert('올바른 전화번호 형식이 아닙니다. (예: 010-1234-5678)');
+      return;
+    }
+
+    updateProfile({ name: name.trim(), phoneNumber: phoneNumber.trim() });
+    onConfirm();
+  };
+
+  return (
+    <div className="bg-white rounded-lg p-6 w-full max-w-md">
+      <h2 className="text-2xl font-bold text-gray-900 mb-2">회원 정보 입력</h2>
+      <p className="text-gray-600 mb-6">
+        서비스 이용을 위해 추가 정보를 입력해주세요.
+      </p>
+
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-4"
+      >
+        <div>
+          <label
+            htmlFor="name"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            이름
+          </label>
+          <input
+            id="name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="홍길동"
+            maxLength={20}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            disabled={isPending}
+          />
+        </div>
+
+        <div>
+          <label
+            htmlFor="phoneNumber"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
+            전화번호
+          </label>
+          <input
+            id="phoneNumber"
+            type="tel"
+            value={phoneNumber}
+            onChange={handlePhoneChange}
+            placeholder="010-1234-5678"
+            maxLength={13}
+            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+            disabled={isPending}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={isPending}
+          className="w-full px-4 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isPending ? '등록 중...' : '등록하기'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default PhoneNumberModal;

--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -1,0 +1,16 @@
+// 상대 시간 포맷 함수
+export function formatRelativeTime(dateString: string): string {
+  const now = new Date();
+  const past = new Date(dateString);
+  const diffInSeconds = Math.floor((now.getTime() - past.getTime()) / 1000);
+
+  if (diffInSeconds < 60) return '방금 전';
+  if (diffInSeconds < 3600) return `${Math.floor(diffInSeconds / 60)}분 전`;
+  if (diffInSeconds < 86400)
+    return `${Math.floor(diffInSeconds / 3600)}시간 전`;
+  if (diffInSeconds < 2592000)
+    return `${Math.floor(diffInSeconds / 86400)}일 전`;
+  if (diffInSeconds < 31536000)
+    return `${Math.floor(diffInSeconds / 2592000)}개월 전`;
+  return `${Math.floor(diffInSeconds / 31536000)}년 전`;
+}

--- a/src/lib/phone-utils.ts
+++ b/src/lib/phone-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * 전화번호를 010-1234-5678 형식으로 포맷팅합니다.
+ * @param value - 포맷팅할 전화번호 문자열
+ * @returns 포맷팅된 전화번호
+ */
+export function formatPhoneNumber(value: string): string {
+  // 숫자만 추출
+  const numbers = value.replace(/\D/g, '');
+
+  // 길이에 따라 포맷팅
+  if (numbers.length <= 3) {
+    return numbers;
+  } else if (numbers.length <= 7) {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3)}`;
+  } else {
+    return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(
+      7,
+      11
+    )}`;
+  }
+}
+
+/**
+ * 전화번호 형식이 올바른지 검증합니다.
+ * @param phoneNumber - 검증할 전화번호
+ * @returns 유효하면 true, 아니면 false
+ */
+export function validatePhoneNumber(phoneNumber: string): boolean {
+  const phoneRegex = /^01[0-9]-?[0-9]{3,4}-?[0-9]{4}$/;
+  return phoneRegex.test(phoneNumber.trim());
+}

--- a/src/lib/server-action.ts
+++ b/src/lib/server-action.ts
@@ -24,6 +24,8 @@ export async function loginAction(
           return '이메일 또는 비밀번호가 올바르지 않습니다.';
         case 'CallbackRouteError':
           return '서버가 잠시 자는중이에요... ㅠ_ㅜ';
+        case 'AccessDenied':
+          return '이미 존재하는 이메일입니다!';
         default:
           console.log('sign in at server action error is', error);
           return '알 수 없는 오류가 발생했습니다.';

--- a/src/lib/server-action.ts
+++ b/src/lib/server-action.ts
@@ -24,8 +24,6 @@ export async function loginAction(
           return '이메일 또는 비밀번호가 올바르지 않습니다.';
         case 'CallbackRouteError':
           return '서버가 잠시 자는중이에요... ㅠ_ㅜ';
-        case 'AccessDenied':
-          return '이미 존재하는 이메일입니다!';
         default:
           console.log('sign in at server action error is', error);
           return '알 수 없는 오류가 발생했습니다.';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -7,7 +7,7 @@ export default auth((req) => {
   const isLoggedIn = !!req.auth;
 
   // 인증이 필요한 경로들
-  const protectedRoutes = ['/books/create', '/mypage', '/admin'];
+  const protectedRoutes = ['/books/create', '/mypage', '/admin', '/activity'];
   const isProtectedRoute = protectedRoutes.some((route) =>
     nextUrl.pathname.startsWith(route)
   );

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -242,11 +242,13 @@ export interface MyReviewData {
   updatedAt: string;
 }
 export interface MyReviewsListData {
-  content: MyReviewData[];
+  reviews: MyReviewData[];
   totalElements: number;
   totalPages: number;
-  size: number;
-  number: number;
+  currentPage: number;
+  pageSize: number;
+  isFirst: number;
+  isLast: number;
 }
 
 export interface MyBookMarkedPostsListData {

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -15,6 +15,18 @@ export interface AuthData {
   refreshTokenExpiresIn: number;
 }
 
+export interface OAuthData {
+  id: number;
+  email: string;
+  name: string;
+  accessToken: string;
+  refreshToken: string;
+  accessTokenExpiresIn: number;
+  refreshTokenExpiresIn: number;
+  isNewUser: boolean;
+  phoneNumber: string | null;
+}
+
 export interface CreateBookPageProps {
   title: string;
   originalText: string;
@@ -95,11 +107,21 @@ export interface MyBooksData {
   isLast: boolean;
 }
 
+export interface RecentBooksData {
+  bookId: string;
+  title: string;
+  status: BookStatus;
+  targetAge: number;
+  thumbnailUrl: string;
+  createdAt: string;
+  viewedAt: string;
+}
+
 export interface UserProfileData {
   id: number;
   email: string;
   name: string;
-  phoneNumber: string;
+  phoneNumber: string | null;
   provider: string;
   role: string;
   status: string;
@@ -207,6 +229,63 @@ export interface LikeData {
   isLiked: boolean;
   likeCount: number;
   action: string;
+}
+
+export interface MyReviewData {
+  reviewId: number;
+  postId: number;
+  bookTitle: string;
+  rating: number;
+  comment: string;
+  isAnonymous: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+export interface MyReviewsListData {
+  content: MyReviewData[];
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  number: number;
+}
+
+export interface MyBookMarkedPostsListData {
+  bookmarks: BookMarkedData[];
+  totalElements: number;
+  totalPages: number;
+  currentPage: number;
+  pageSize: number;
+  isLast: boolean;
+  isFirst: boolean;
+}
+
+export interface BookMarkedData {
+  bookMarkId: number;
+  postId: number;
+  postTitle: string;
+  thumbnailUrl: string;
+  bookMarkedAt: string;
+  post: {
+    postId: number;
+    title: string;
+    content: string;
+    authorId: number;
+    authorName: string;
+    viewCount: number;
+    likeCount: number;
+    createdAt: string;
+    book: {
+      bookId: string;
+      originalTitle: string;
+      thumbnailUrl: string;
+      targetAge: number;
+      theme: BookTheme;
+      style: BookStyle;
+      totalPages: number;
+    };
+    averageRating?: number;
+    reviewCount: number;
+  };
 }
 
 export enum BookStatus {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -7,6 +7,7 @@ import 'next-auth/jwt';
 declare module 'next-auth' {
   interface Session {
     accessToken?: string;
+    isNewUser?: boolean;
     error?: string;
     user: {
       id: string;
@@ -22,12 +23,14 @@ declare module 'next-auth' {
     accessToken: string;
     refreshToken: string;
     accessTokenExpiresIn: number;
+    isNewUser?: boolean;
   }
 }
 
 // JWT 토큰에 추가할 타입 선언
 declare module 'next-auth/jwt' {
   interface JWT {
+    isNewUser?: boolean;
     accessToken?: string;
     refreshToken?: string;
     accessTokenExpiresIn?: number; // access_token 만료 시간 (초 단위)


### PR DESCRIPTION
## Summary

  이번 PR은 OAuth 간편 로그인 기능과 사용자 활동 페이지를 추가합니다.

  ### 주요 변경사항

  #### 1. OAuth 간편 로그인 (Google, Kakao)
  - NextAuth에 Google, Kakao OAuth 프로바이더 추가
  - 백엔드 `/api/v1/auth/oauth/simple` 엔드포인트와 연동
  - 로그인 폼에 소셜 로그인 버튼 추가
  - 신규 OAuth 사용자를 위한 전화번호 수집 모달

  #### 2. 인증 에러 처리
  - 다양한 NextAuth 에러 타입에 대한 한국어 에러 페이지
  - 사용자 친화적인 에러 메시지 및 재시도 기능

  #### 3. 내 활동 페이지
  - 최근 본 책 목록
  - 작성한 리뷰 목록
  - 북마크한 게시글 목록
  - 네비게이션에 "내 활동" 메뉴 추가

  #### 4. 레이아웃 및 UI 개선
  - 헤더 fixed 포지션으로 변경 (스크롤 시 항상 표시)
  - 전체 너비 일관성 확보
  - 반응형 디자인 개선 (모바일 대응)

  #### 5. 책 상세 조회 개선
  - 인증된 요청을 위한 accessToken 전달
  - 프리페치 로직 개선 (hover 시 미리 로드)
  - 에러 처리 개선 (BOOK_4005)

  ### 커밋 내역
  - feat: add OAuth social login integration
  - feat: add phone number collection for new OAuth users
  - feat: add authentication error page
  - feat: add activity page for user activities
  - refactor: improve layout consistency and responsive design
  - refactor: improve book detail fetching and prefetch logic

  ## Test plan
  - [ ] Google 로그인 테스트 (신규/기존 사용자)
  - [x] Kakao 로그인 테스트 (신규/기존 사용자)
  - [x] 신규 OAuth 사용자 전화번호 모달 확인
  - [x] 인증 에러 페이지 확인 (잘못된 자격증명, 중복 이메일 등)
  - [x] 내 활동 페이지 접근 및 데이터 표시 확인
  - [ ] 반응형 디자인 확인 (모바일, 태블릿, 데스크톱)
  - [x] 헤더 스크롤 동작 확인
  - [x] 책 프리페치 및 상세 조회 확인

  🤖 Generated with [Claude Code](https://claude.com/claude-code)