### PR TITLE
Fix library detail page layout width

### DIFF
--- a/src/app/library/[slug]/page.tsx
+++ b/src/app/library/[slug]/page.tsx
@@ -27,7 +27,7 @@ export default async function LibraryDetailPage(props: {
   const dehydratedState = dehydrate(queryClient);
 
   return (
-    <main>
+    <main className="w-full mx-auto p-6 md:p-8 my-8">
       <HydrationBoundary state={dehydratedState}>
         <BookDetailInfo slug={slug} />
         <BookReviews slug={slug} />

--- a/src/components/library/book-detail-info.tsx
+++ b/src/components/library/book-detail-info.tsx
@@ -348,7 +348,7 @@ export default function BookDetailInfo({ slug }: BookDetailInfoProps) {
   return (
     <div
       onMouseEnter={handleMouseEnter}
-      className="bg-white rounded-lg shadow-lg p-6 md:p-8"
+      className="bg-white w-full rounded-lg shadow-lg p-6 md:p-8"
     >
       <div className="flex flex-col md:flex-row gap-8">
         {/* 왼쪽: 책 표지 */}


### PR DESCRIPTION
## Summary
- Improve library detail page layout with proper width and spacing constraints
- Add `w-full mx-auto p-6 md:p-8 my-8` classes to main container for better responsive design
- Ensure book detail info component spans full width

## Test plan
- [ ] Verify library detail page displays correctly on desktop
- [ ] Verify library detail page displays correctly on mobile/tablet
- [ ] Check that content is properly centered with appropriate padding
- [ ] Ensure no horizontal overflow issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)