### PR TITLE
feat: 카카오 애드핏 광고 시스템 구현 및 반응형 처리

### DIFF
--- a/src/app/activity/page.tsx
+++ b/src/app/activity/page.tsx
@@ -7,6 +7,7 @@ import { myReviewsOption } from '@/components/activity/my-reviews-option';
 import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import LikedPosts from '@/components/activity/liked-posts';
 import { likedPostsOption } from '@/components/activity/liked-posts-option';
+import AdBannersWrapper from '@/components/ad/ad-banners-wrapper';
 
 const ActivityPage = async () => {
   const queryClient = getQueryClient();
@@ -25,15 +26,17 @@ const ActivityPage = async () => {
   const dehydratedState = dehydrate(queryClient);
 
   return (
-    <main className="max-w-7xl mx-auto p-6 md:p-8 my-8">
-      <div className="mb-8">
+    <main className="max-w-7xl mx-auto flex flex-col gap-8 items-center p-6 md:p-8 my-8">
+      <div className="w-full flex flex-col items-start">
         <h1 className="text-4xl font-bold text-gray-900 mb-3">내 활동</h1>
         <p className="text-lg text-gray-600">
           최근 본 책, 좋아요한 게시물, 작성한 리뷰를 확인하세요
         </p>
       </div>
 
-      <div className="space-y-12">
+      <AdBannersWrapper />
+
+      <div className="space-y-12 w-full">
         <HydrationBoundary state={dehydratedState}>
           <RecentBooks />
           <LikedPosts />

--- a/src/app/books/create/page.tsx
+++ b/src/app/books/create/page.tsx
@@ -1,15 +1,20 @@
+import AdBannersWrapper from '@/components/ad/ad-banners-wrapper';
 import CreateBookForm from '@/components/book/create-book-form';
 
 const CreateBookPage = () => {
   return (
-    <div className="p-8 md:p-12 max-w-4xl mx-auto">
-      <h1 className="text-4xl md:text-5xl font-bold text-gray-800 mb-2">
-        새 동화책 만들기 🎨
-      </h1>
-      <p className="text-gray-600 mb-8">
-        상상 속 이야기를 마음껏 적어주세요. 각 문단이 동화책의 한 페이지가
-        됩니다.
-      </p>
+    <div className="p-8 md:p-12 max-w-4xl mx-auto flex flex-col gap-8">
+      <div>
+        <h1 className="text-4xl md:text-5xl font-bold text-gray-800 mb-2">
+          새 동화책 만들기 🎨
+        </h1>
+        <p className="text-gray-600">
+          상상 속 이야기를 마음껏 적어주세요. 각 문단이 동화책의 한 페이지가
+          됩니다.
+        </p>
+      </div>
+
+      <AdBannersWrapper />
 
       <CreateBookForm />
     </div>

--- a/src/app/books/page.tsx
+++ b/src/app/books/page.tsx
@@ -1,3 +1,4 @@
+import AdBannersWrapper from '@/components/ad/ad-banners-wrapper';
 import CreateBookButton from '@/components/book/create-book-button';
 import BookThumbnail from '@/components/mypage/book-thumbnail';
 import { BookStatus } from '@/types/api';
@@ -32,22 +33,24 @@ const sampleBooks = [
 
 const BooksPage = () => {
   return (
-    <main className="p-8 md:p-12">
-      <h1 className="text-4xl md:text-5xl font-bold text-gray-800 mb-4">
-        동화책 세상 📚
-      </h1>
-      <p className="text-lg text-gray-600 mb-8">
-        나만의 동화책을 만들거나 다른 친구들의 멋진 이야기를 구경해보세요!
-      </p>
-
-      <div className="my-10">
+    <main className="flex flex-col gap-8 p-8 md:p-12">
+      <section className="flex flex-col items-start gap-6">
+        <h1 className="text-4xl md:text-5xl font-bold text-gray-800">
+          동화책 세상 📚
+        </h1>
+        <p className="text-lg text-gray-600">
+          나만의 동화책을 만들거나 다른 친구들의 멋진 이야기를 구경해보세요!
+        </p>
         <CreateBookButton />
+      </section>
+
+      <div>
+        <hr className="my-10" />
+        <AdBannersWrapper />
       </div>
 
-      <hr className="my-12" />
-
-      <section>
-        <h2 className="text-3xl font-bold text-gray-800 mb-6">
+      <section className="flex flex-col gap-6">
+        <h2 className="text-3xl font-bold text-gray-800">
           ✨ 완성된 동화책 구경하기
         </h2>
         <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-6">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default async function RootLayout({
 
   return (
     <html lang="en">
-      <body className="flex flex-col items-center min-h-screen antialiased pt-16">
+      <body className="flex flex-col items-center min-h-screen antialiased pt-16 pb-16">
         <AuthProvider session={session}>
           <ReactQueryProvider>
             <Header />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import GlobalModal from '@/components/ui/modal/global-modal';
 import ReactQueryProvider from '@/components/provider/react-query-provider';
 import AuthProvider from '@/components/provider/auth-provider';
 import { auth } from '@/auth';
+import MobileFooter from '@/components/layout/mobile-footer';
 
 export const metadata: Metadata = {
   title: 'my fairy tale',
@@ -34,6 +35,7 @@ export default async function RootLayout({
             <Header />
             {children}
             <GlobalModal />
+            <MobileFooter />
             <Footer />
           </ReactQueryProvider>
         </AuthProvider>

--- a/src/app/library/[slug]/page.tsx
+++ b/src/app/library/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { auth } from '@/auth';
+import AdBannersWrapper from '@/components/ad/ad-banners-wrapper';
 import BookDetailInfo from '@/components/library/book-detail-info';
 import BookReviews from '@/components/library/book-reviews';
 import { libraryDetailBookOption } from '@/components/library/library-detail-book-option';
@@ -27,10 +28,13 @@ export default async function LibraryDetailPage(props: {
   const dehydratedState = dehydrate(queryClient);
 
   return (
-    <main className="w-full mx-auto p-6 md:p-8 my-8">
+    <main className="w-full mx-auto p-6 md:p-8">
       <HydrationBoundary state={dehydratedState}>
-        <BookDetailInfo slug={slug} />
-        <BookReviews slug={slug} />
+        <div className="flex flex-col gap-8 md:gap-12">
+          <BookDetailInfo slug={slug} />
+          <AdBannersWrapper />
+          <BookReviews slug={slug} />
+        </div>
       </HydrationBoundary>
     </main>
   );

--- a/src/app/library/create/page.tsx
+++ b/src/app/library/create/page.tsx
@@ -1,14 +1,17 @@
+import AdBannersWrapper from '@/components/ad/ad-banners-wrapper';
 import CreatePostForm from '@/components/library/create-post-form';
 
 const CreatePostPage = () => {
   return (
-    <main className="max-w-3xl w-full mx-auto p-6 md:p-8 my-8">
-      <div className="mb-8">
+    <main className="flex flex-col items-center gap-8 max-w-4xl w-full mx-auto p-6 md:p-8 my-8">
+      <div className="w-full flex flex-col items-start">
         <h1 className="text-3xl font-bold text-gray-900 mb-2">책 게시하기</h1>
         <p className="text-gray-600">
           내가 만든 동화책을 다른 사람들과 공유해보세요
         </p>
       </div>
+
+      <AdBannersWrapper />
 
       <CreatePostForm />
     </main>

--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -9,6 +9,7 @@ import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import { libraryBookOption } from '@/components/library/library-book-option';
 import { auth } from '@/auth';
 import { redirect } from 'next/navigation';
+import AdBannersWrapper from '@/components/ad/ad-banners-wrapper';
 
 export default async function LibraryPage({
   searchParams,
@@ -38,8 +39,8 @@ export default async function LibraryPage({
   const dehydratedState = dehydrate(queryClient);
 
   return (
-    <main className="max-w-7xl mx-auto p-6 md:p-8 my-8">
-      <div className="w-full mb-6 flex items-end justify-between">
+    <main className="max-w-7xl mx-auto flex flex-col items-center gap-8 p-6 md:p-8">
+      <div className="w-full flex items-end justify-between">
         <div>
           <h1 className="text-4xl font-bold text-gray-900 mb-3">동화 광장</h1>
           <p className="text-lg text-gray-600 max-md:hidden">
@@ -54,6 +55,8 @@ export default async function LibraryPage({
           <FaPlus />책 게시하기
         </Link>
       </div>
+
+      <AdBannersWrapper />
 
       <LibraryFilter currentSort={sort} />
 

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -6,6 +6,7 @@ import { auth } from '@/auth';
 import AccountSettings from '@/components/mypage/account-settings';
 import UserProfile from '@/components/mypage/user-profile';
 import MyBookList from '@/components/mypage/my-book-list';
+import MobileFooterInfo from '@/components/layout/mobile-footer-info';
 
 export default async function MyPage() {
   const queryClient = getQueryClient();
@@ -36,6 +37,8 @@ export default async function MyPage() {
 
         <AccountSettings accessToken={session?.accessToken} />
       </div>
+
+      <MobileFooterInfo />
     </main>
   );
 }

--- a/src/components/ad/ad-banner-mobile.tsx
+++ b/src/components/ad/ad-banner-mobile.tsx
@@ -1,30 +1,22 @@
 import AdBanner from './ad-banner';
+import { AD_CONFIG } from './ad-config';
 
 interface AdBannerMobileProps {
   fixed?: boolean; // 하단 고정 여부
 }
 
 const AdBannerMobile = ({ fixed = false }: AdBannerMobileProps) => {
-  const adUnit = 'DAN-hc06tiFHsYYdon85';
   if (fixed) {
     return (
       <div className="md:hidden fixed bottom-16 left-0 right-0 z-40 bg-white border-t border-gray-200 shadow-lg">
-        <AdBanner
-          adUnit={adUnit}
-          width={320}
-          height={50}
-        />
+        <AdBanner {...AD_CONFIG.MOBILE_BANNER} />
       </div>
     );
   }
 
   return (
     <div className="md:hidden w-full py-4 bg-gray-50">
-      <AdBanner
-        adUnit={adUnit}
-        width={320}
-        height={50}
-      />
+      <AdBanner {...AD_CONFIG.MOBILE_BANNER} />
     </div>
   );
 };

--- a/src/components/ad/ad-banner-mobile.tsx
+++ b/src/components/ad/ad-banner-mobile.tsx
@@ -1,0 +1,32 @@
+import AdBanner from './ad-banner';
+
+interface AdBannerMobileProps {
+  fixed?: boolean; // 하단 고정 여부
+}
+
+const AdBannerMobile = ({ fixed = false }: AdBannerMobileProps) => {
+  const adUnit = 'DAN-hc06tiFHsYYdon85';
+  if (fixed) {
+    return (
+      <div className="md:hidden fixed bottom-16 left-0 right-0 z-40 bg-white border-t border-gray-200 shadow-lg">
+        <AdBanner
+          adUnit={adUnit}
+          width={320}
+          height={50}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="md:hidden w-full py-4 bg-gray-50">
+      <AdBanner
+        adUnit={adUnit}
+        width={320}
+        height={50}
+      />
+    </div>
+  );
+};
+
+export default AdBannerMobile;

--- a/src/components/ad/ad-banner-pc.tsx
+++ b/src/components/ad/ad-banner-pc.tsx
@@ -1,0 +1,16 @@
+import AdBanner from './ad-banner';
+
+const AdBannerPC = () => {
+  const adUnit = 'DAN-QyqLwiahlSFDhmcA';
+  return (
+    <div className="hidden md:block w-full py-6 bg-gray-50">
+      <AdBanner
+        adUnit={adUnit}
+        width={728}
+        height={90}
+      />
+    </div>
+  );
+};
+
+export default AdBannerPC;

--- a/src/components/ad/ad-banner-pc.tsx
+++ b/src/components/ad/ad-banner-pc.tsx
@@ -1,14 +1,10 @@
 import AdBanner from './ad-banner';
+import { AD_CONFIG } from './ad-config';
 
 const AdBannerPC = () => {
-  const adUnit = 'DAN-QyqLwiahlSFDhmcA';
   return (
     <div className="hidden md:block w-full py-6 bg-gray-50">
-      <AdBanner
-        adUnit={adUnit}
-        width={728}
-        height={90}
-      />
+      <AdBanner {...AD_CONFIG.PC_BANNER} />
     </div>
   );
 };

--- a/src/components/ad/ad-banner.tsx
+++ b/src/components/ad/ad-banner.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+interface AdBannerProps {
+  adUnit: string;
+  width: number;
+  height: number;
+  className?: string;
+}
+
+const AdBanner = ({ adUnit, width, height, className = '' }: AdBannerProps) => {
+  return (
+    <div className={`flex items-center justify-center ${className}`}>
+      <ins
+        className="kakao_ad_area"
+        style={{ display: 'none' }}
+        data-ad-unit={adUnit}
+        data-ad-width={width}
+        data-ad-height={height}
+      />
+      <script
+        type="text/javascript"
+        src="//t1.daumcdn.net/kas/static/ba.min.js"
+        async
+      ></script>
+    </div>
+  );
+};
+
+export default AdBanner;

--- a/src/components/ad/ad-banner.tsx
+++ b/src/components/ad/ad-banner.tsx
@@ -9,7 +9,40 @@ interface AdBannerProps {
   className?: string;
 }
 
+declare global {
+  interface Window {
+    adfit?: {
+      destroy?: (unit: string) => void;
+    };
+  }
+}
+
 const AdBanner = ({ adUnit, width, height, className = '' }: AdBannerProps) => {
+  const scriptElementRef = useRef<HTMLScriptElement | null>(null);
+
+  useEffect(() => {
+    // 스크립트 동적 로드
+    const script = document.createElement('script');
+    script.src = '//t1.daumcdn.net/kas/static/ba.min.js';
+    script.async = true;
+
+    scriptElementRef.current = script;
+    document.body.appendChild(script);
+
+    // cleanup: 컴포넌트 언마운트 시 광고 정리
+    return () => {
+      if (scriptElementRef.current) {
+        document.body.removeChild(scriptElementRef.current);
+      }
+
+      // adfit.destroy 호출 (존재하는 경우)
+      const globalAdfit = 'adfit' in window ? window.adfit : null;
+      if (globalAdfit && globalAdfit.destroy) {
+        globalAdfit.destroy(adUnit);
+      }
+    };
+  }, [adUnit]);
+
   return (
     <div className={`flex items-center justify-center ${className}`}>
       <ins
@@ -19,11 +52,6 @@ const AdBanner = ({ adUnit, width, height, className = '' }: AdBannerProps) => {
         data-ad-width={width}
         data-ad-height={height}
       />
-      <script
-        type="text/javascript"
-        src="//t1.daumcdn.net/kas/static/ba.min.js"
-        async
-      ></script>
     </div>
   );
 };

--- a/src/components/ad/ad-banners-wrapper.tsx
+++ b/src/components/ad/ad-banners-wrapper.tsx
@@ -1,33 +1,15 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import AdBannerPC from './ad-banner-pc';
 import AdBannerMobile from './ad-banner-mobile';
+import { useIsMobile } from '@/hooks/useMediaQuery';
 
 interface AdBannersWrapperProps {
   mobileFixed?: boolean;
 }
 
 const AdBannersWrapper = ({ mobileFixed = false }: AdBannersWrapperProps) => {
-  const [isMobile, setIsMobile] = useState<boolean | null>(null);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(max-width: 767px)');
-
-    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
-      setIsMobile(e.matches);
-    };
-
-    // 초기값 설정
-    handleChange(mediaQuery);
-
-    // 이벤트 리스너 등록
-    mediaQuery.addEventListener('change', handleChange);
-
-    return () => {
-      mediaQuery.removeEventListener('change', handleChange);
-    };
-  }, []);
+  const isMobile = useIsMobile();
 
   // 초기 렌더링 시 깜빡임 방지 (SSR 대응)
   if (isMobile === null) {

--- a/src/components/ad/ad-banners-wrapper.tsx
+++ b/src/components/ad/ad-banners-wrapper.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import AdBannerPC from './ad-banner-pc';
+import AdBannerMobile from './ad-banner-mobile';
+
+interface AdBannersWrapperProps {
+  mobileFixed?: boolean;
+}
+
+const AdBannersWrapper = ({ mobileFixed = false }: AdBannersWrapperProps) => {
+  const [isMobile, setIsMobile] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(max-width: 767px)');
+
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(e.matches);
+    };
+
+    // 초기값 설정
+    handleChange(mediaQuery);
+
+    // 이벤트 리스너 등록
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
+  // 초기 렌더링 시 깜빡임 방지 (SSR 대응)
+  if (isMobile === null) {
+    return null;
+  }
+
+  return isMobile ? (
+    <AdBannerMobile fixed={mobileFixed} />
+  ) : (
+    <AdBannerPC />
+  );
+};
+
+export default AdBannersWrapper;

--- a/src/components/ad/ad-config.ts
+++ b/src/components/ad/ad-config.ts
@@ -1,0 +1,57 @@
+/**
+ * 카카오 애드핏 광고 설정
+ */
+
+export const AD_UNITS = {
+  /** PC 배너 광고 (728x90) */
+  PC_BANNER: 'DAN-QyqLwiahlSFDhmcA',
+
+  /** 모바일 배너 광고 (320x50) */
+  MOBILE_BANNER: 'DAN-hc06tiFHsYYdon85',
+
+  /** 사이드바 광고 (160x600) */
+  SIDEBAR_BANNER: 'DAN-8Fa5mGlEZJyUwI0K',
+} as const;
+
+export const AD_SIZES = {
+  /** PC 배너 크기 (728x90) */
+  PC_BANNER: {
+    width: 728,
+    height: 90,
+  },
+
+  /** 모바일 배너 크기 (320x50) */
+  MOBILE_BANNER: {
+    width: 320,
+    height: 50,
+  },
+
+  /** 사이드바 배너 크기 (160x600) */
+  SIDEBAR_BANNER: {
+    width: 160,
+    height: 600,
+  },
+} as const;
+
+/**
+ * 광고 설정을 하나의 객체로 통합
+ */
+export const AD_CONFIG = {
+  PC_BANNER: {
+    adUnit: AD_UNITS.PC_BANNER,
+    ...AD_SIZES.PC_BANNER,
+  },
+  MOBILE_BANNER: {
+    adUnit: AD_UNITS.MOBILE_BANNER,
+    ...AD_SIZES.MOBILE_BANNER,
+  },
+  SIDEBAR_BANNER: {
+    adUnit: AD_UNITS.SIDEBAR_BANNER,
+    ...AD_SIZES.SIDEBAR_BANNER,
+  },
+} as const;
+
+// 타입 export
+export type AdUnitKey = keyof typeof AD_UNITS;
+export type AdSizeKey = keyof typeof AD_SIZES;
+export type AdConfigKey = keyof typeof AD_CONFIG;

--- a/src/components/ad/ad-sidebar.tsx
+++ b/src/components/ad/ad-sidebar.tsx
@@ -1,0 +1,26 @@
+import AdBanner from './ad-banner';
+
+interface AdSidebarProps {
+  sticky?: boolean; // sticky 여부
+}
+
+const AdSidebar = ({ sticky = true }: AdSidebarProps) => {
+  const adUnit = 'DAN-8Fa5mGlEZJyUwI0K';
+  return (
+    <aside
+      className={`hidden lg:block ${
+        sticky ? 'sticky top-20' : ''
+      } w-[160px] flex-shrink-0`}
+    >
+      <div className="bg-gray-50 rounded-lg overflow-hidden">
+        <AdBanner
+          adUnit={adUnit}
+          width={160}
+          height={600}
+        />
+      </div>
+    </aside>
+  );
+};
+
+export default AdSidebar;

--- a/src/components/ad/ad-sidebar.tsx
+++ b/src/components/ad/ad-sidebar.tsx
@@ -1,11 +1,11 @@
 import AdBanner from './ad-banner';
+import { AD_CONFIG } from './ad-config';
 
 interface AdSidebarProps {
   sticky?: boolean; // sticky 여부
 }
 
 const AdSidebar = ({ sticky = true }: AdSidebarProps) => {
-  const adUnit = 'DAN-8Fa5mGlEZJyUwI0K';
   return (
     <aside
       className={`hidden lg:block ${
@@ -13,11 +13,7 @@ const AdSidebar = ({ sticky = true }: AdSidebarProps) => {
       } w-[160px] flex-shrink-0`}
     >
       <div className="bg-gray-50 rounded-lg overflow-hidden">
-        <AdBanner
-          adUnit={adUnit}
-          width={160}
-          height={600}
-        />
+        <AdBanner {...AD_CONFIG.SIDEBAR_BANNER} />
       </div>
     </aside>
   );

--- a/src/components/book/book-display.tsx
+++ b/src/components/book/book-display.tsx
@@ -127,7 +127,7 @@ const BookDisplay = ({ bookData }: { bookData: BookData }) => {
   return (
     <div
       ref={fullscreenContainerRef}
-      className="w-full h-auto relative flex flex-col items-center justify-center bg-gray-100 p-4"
+      className="w-full h-auto relative hidden md:flex flex-col items-center justify-center bg-gray-100 p-4"
     >
       <h1 className="text-3xl md:text-5xl font-bold text-gray-800 mb-8 text-center">
         {bookData.title}

--- a/src/components/book/book-display.tsx
+++ b/src/components/book/book-display.tsx
@@ -3,9 +3,10 @@
 import { BookData } from '@/types/api';
 import { useEffect, useRef, useState } from 'react';
 import BookPage from '@/components/book/book-page';
+import AdBannersWrapper from '../ad/ad-banners-wrapper';
 
 // 2. 전체화면 아이콘 SVG 추가
-const FullscreenEnterIcon = () => (
+export const FullscreenEnterIcon = () => (
   <svg
     width="24"
     height="24"
@@ -19,7 +20,7 @@ const FullscreenEnterIcon = () => (
     <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
   </svg>
 );
-const FullscreenExitIcon = () => (
+export const FullscreenExitIcon = () => (
   <svg
     width="24"
     height="24"
@@ -125,60 +126,63 @@ const BookDisplay = ({ bookData }: { bookData: BookData }) => {
   };
 
   return (
-    <div
-      ref={fullscreenContainerRef}
-      className="w-full h-auto relative hidden md:flex flex-col items-center justify-center bg-gray-100 p-4"
-    >
-      <h1 className="text-3xl md:text-5xl font-bold text-gray-800 mb-8 text-center">
-        {bookData.title}
-      </h1>
-
-      <div className="flex items-center gap-2 sm:gap-6 w-full max-w-7xl">
-        {/* 이전 페이지 버튼 */}
-        <button
-          onClick={goToPreviousPage}
-          disabled={currentPageIndex === 0}
-          className="bg-white text-gray-800 rounded-full w-12 h-12 md:w-14 md:h-14 text-3xl flex items-center justify-center shadow-lg transition hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
-        >
-          &lt;
-        </button>
-
-        {/* 책 페이지 영역 - 2. 크기 고정 및 레이아웃 안정화 */}
-        <div className="flex-grow h-full grid grid-cols-1 md:grid-cols-2 gap-4 bg-white p-4 sm:p-6 rounded-2xl shadow-2xl border border-gray-200">
-          <BookPage
-            pageData={leftPage}
-            position="left"
-            onPlayAudio={playTts}
-          />
-          <BookPage
-            pageData={rightPage}
-            position="right"
-            onPlayAudio={playTts}
-          />
-        </div>
-
-        {/* 다음 페이지 버튼 */}
-        <button
-          onClick={goToNextPage}
-          disabled={!rightPage || !bookData.pages[currentPageIndex + 2]} // 다음 펼칠 페이지가 있는지 확인
-          className="bg-white text-gray-800 rounded-full w-12 h-12 md:w-14 md:h-14 text-3xl flex items-center justify-center shadow-lg transition hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
-        >
-          &gt;
-        </button>
-      </div>
-      <button
-        onClick={toggleFullscreen}
-        className="absolute bottom-0 right-0 mb-4 mr-4 bg-white text-gray-800 rounded-full w-12 h-12 md:w-14 md:h-14 flex items-center justify-center shadow-lg transition hover:bg-gray-200 flex-shrink-0"
+    <>
+      <div
+        ref={fullscreenContainerRef}
+        className="w-full h-auto relative hidden md:flex flex-col items-center justify-center bg-gray-100 p-4"
       >
-        {isFullscreen ? <FullscreenExitIcon /> : <FullscreenEnterIcon />}
-      </button>
+        <h1 className="text-3xl md:text-5xl font-bold text-gray-800 mb-8 text-center">
+          {bookData.title}
+        </h1>
 
-      <audio
-        ref={audioRef}
-        controls
-        className="hidden"
-      />
-    </div>
+        <div className="flex items-center gap-2 sm:gap-6 w-full max-w-7xl">
+          {/* 이전 페이지 버튼 */}
+          <button
+            onClick={goToPreviousPage}
+            disabled={currentPageIndex === 0}
+            className="bg-white text-gray-800 rounded-full w-12 h-12 md:w-14 md:h-14 text-3xl flex items-center justify-center shadow-lg transition hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+          >
+            &lt;
+          </button>
+
+          {/* 책 페이지 영역 - 2. 크기 고정 및 레이아웃 안정화 */}
+          <div className="flex-grow h-full grid grid-cols-1 md:grid-cols-2 gap-4 bg-white p-4 sm:p-6 rounded-2xl shadow-2xl border border-gray-200">
+            <BookPage
+              pageData={leftPage}
+              position="left"
+              onPlayAudio={playTts}
+            />
+            <BookPage
+              pageData={rightPage}
+              position="right"
+              onPlayAudio={playTts}
+            />
+          </div>
+
+          {/* 다음 페이지 버튼 */}
+          <button
+            onClick={goToNextPage}
+            disabled={!rightPage || !bookData.pages[currentPageIndex + 2]} // 다음 펼칠 페이지가 있는지 확인
+            className="bg-white text-gray-800 rounded-full w-12 h-12 md:w-14 md:h-14 text-3xl flex items-center justify-center shadow-lg transition hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+          >
+            &gt;
+          </button>
+        </div>
+        <button
+          onClick={toggleFullscreen}
+          className="absolute bottom-0 right-0 mb-4 mr-4 bg-white text-gray-800 rounded-full w-12 h-12 md:w-14 md:h-14 flex items-center justify-center shadow-lg transition hover:bg-gray-200 flex-shrink-0"
+        >
+          {isFullscreen ? <FullscreenExitIcon /> : <FullscreenEnterIcon />}
+        </button>
+
+        <audio
+          ref={audioRef}
+          controls
+          className="hidden"
+        />
+      </div>
+      <AdBannersWrapper />
+    </>
   );
 };
 

--- a/src/components/book/book-fetching.tsx
+++ b/src/components/book/book-fetching.tsx
@@ -4,6 +4,7 @@ import BookDisplay from './book-display';
 import { useSession } from 'next-auth/react';
 import { useQuery } from '@tanstack/react-query';
 import { bookDetailOption } from './book-detail-option';
+import MobileBookDisplay from './mobile-book-display';
 
 export default function BookFetching({ slug }: { slug: string }) {
   const { data: session } = useSession();
@@ -18,5 +19,10 @@ export default function BookFetching({ slug }: { slug: string }) {
   if (!bookData) return <div>해당 책을 찾을 수 없습니다.</div>;
   if (error) return <div>오류: {error.message}</div>;
 
-  return <BookDisplay bookData={bookData} />;
+  return (
+    <>
+      <BookDisplay bookData={bookData} />
+      <MobileBookDisplay bookData={bookData} />
+    </>
+  );
 }

--- a/src/components/book/book-fetching.tsx
+++ b/src/components/book/book-fetching.tsx
@@ -5,35 +5,17 @@ import { useSession } from 'next-auth/react';
 import { useQuery } from '@tanstack/react-query';
 import { bookDetailOption } from './book-detail-option';
 import MobileBookDisplay from './mobile-book-display';
-import { useEffect, useState } from 'react';
+import { useIsMobile } from '@/hooks/useMediaQuery';
 
 export default function BookFetching({ slug }: { slug: string }) {
   const { data: session } = useSession();
-  const [isMobile, setIsMobile] = useState<boolean | null>(null);
+  const isMobile = useIsMobile();
 
   const {
     data: bookData,
     isLoading,
     error,
   } = useQuery(bookDetailOption(slug, session?.accessToken));
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(max-width: 767px)');
-
-    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
-      setIsMobile(e.matches);
-    };
-
-    // 초기값 설정
-    handleChange(mediaQuery);
-
-    // 이벤트 리스너 등록
-    mediaQuery.addEventListener('change', handleChange);
-
-    return () => {
-      mediaQuery.removeEventListener('change', handleChange);
-    };
-  }, []);
 
   if (isLoading) return <div>책을 불러오는 중...</div>;
   if (!bookData) return <div>해당 책을 찾을 수 없습니다.</div>;

--- a/src/components/book/book-fetching.tsx
+++ b/src/components/book/book-fetching.tsx
@@ -5,9 +5,11 @@ import { useSession } from 'next-auth/react';
 import { useQuery } from '@tanstack/react-query';
 import { bookDetailOption } from './book-detail-option';
 import MobileBookDisplay from './mobile-book-display';
+import { useEffect, useState } from 'react';
 
 export default function BookFetching({ slug }: { slug: string }) {
   const { data: session } = useSession();
+  const [isMobile, setIsMobile] = useState<boolean | null>(null);
 
   const {
     data: bookData,
@@ -15,14 +17,36 @@ export default function BookFetching({ slug }: { slug: string }) {
     error,
   } = useQuery(bookDetailOption(slug, session?.accessToken));
 
+  useEffect(() => {
+    const mediaQuery = window.matchMedia('(max-width: 767px)');
+
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(e.matches);
+    };
+
+    // 초기값 설정
+    handleChange(mediaQuery);
+
+    // 이벤트 리스너 등록
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, []);
+
   if (isLoading) return <div>책을 불러오는 중...</div>;
   if (!bookData) return <div>해당 책을 찾을 수 없습니다.</div>;
   if (error) return <div>오류: {error.message}</div>;
 
-  return (
-    <>
-      <BookDisplay bookData={bookData} />
-      <MobileBookDisplay bookData={bookData} />
-    </>
+  // 초기 렌더링 시 깜빡임 방지 (SSR 대응)
+  if (isMobile === null) {
+    return null;
+  }
+
+  return isMobile ? (
+    <MobileBookDisplay bookData={bookData} />
+  ) : (
+    <BookDisplay bookData={bookData} />
   );
 }

--- a/src/components/book/mobile-book-display.tsx
+++ b/src/components/book/mobile-book-display.tsx
@@ -3,14 +3,43 @@
 import { BookData } from '@/types/api';
 import { useEffect, useRef, useState } from 'react';
 import BookPage from '@/components/book/book-page';
+import AdBannersWrapper from '../ad/ad-banners-wrapper';
+import { FullscreenEnterIcon, FullscreenExitIcon } from './book-display';
 
 const MobileBookDisplay = ({ bookData }: { bookData: BookData }) => {
   const [currentPageIndex, setCurrentPageIndex] = useState(0);
   const [touchStart, setTouchStart] = useState(0);
   const [touchEnd, setTouchEnd] = useState(0);
   const audioRef = useRef<HTMLAudioElement>(null);
+  const fullscreenContainerRef = useRef<HTMLDivElement>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
 
   const minSwipeDistance = 50; //최소 스와이프 거리
+
+  const toggleFullscreen = () => {
+    const elem = fullscreenContainerRef.current;
+    if (!elem) return;
+
+    if (!document.fullscreenElement) {
+      elem.requestFullscreen().catch((err) => {
+        alert(
+          `전체 화면 모드를 시작할 수 없습니다: ${err.message} (${err.name})`
+        );
+      });
+    } else {
+      document.exitFullscreen();
+    }
+  };
+
+  useEffect(() => {
+    const handleFullscreenChange = () => {
+      setIsFullscreen(!!document.fullscreenElement);
+    };
+
+    document.addEventListener('fullscreenchange', handleFullscreenChange);
+    return () =>
+      document.removeEventListener('fullscreenchange', handleFullscreenChange);
+  }, []);
 
   useEffect(() => {
     // 다음 페이지 미리 로드
@@ -91,7 +120,10 @@ const MobileBookDisplay = ({ bookData }: { bookData: BookData }) => {
   };
 
   return (
-    <div className="w-full min-h-screen flex md:hidden flex-col bg-gray-100 pb-20">
+    <div
+      ref={fullscreenContainerRef}
+      className="w-full min-h-screen flex md:hidden flex-col bg-gray-100 pb-20"
+    >
       {/* 헤더 */}
       <div className="bg-white border-b border-gray-200 p-4 sticky top-0 z-10 shadow-sm">
         <h1 className="text-xl font-bold text-gray-800 text-center">
@@ -112,6 +144,7 @@ const MobileBookDisplay = ({ bookData }: { bookData: BookData }) => {
             position="left"
             onPlayAudio={playTts}
           />
+          <AdBannersWrapper />
         </div>
       </div>
 
@@ -157,6 +190,12 @@ const MobileBookDisplay = ({ bookData }: { bookData: BookData }) => {
           </button>
         </div>
       </div>
+      <button
+        onClick={toggleFullscreen}
+        className="absolute bottom-0 right-0 mb-4 mr-4 bg-white text-gray-800 rounded-full w-12 h-12 md:w-14 md:h-14 flex items-center justify-center shadow-lg transition hover:bg-gray-200 flex-shrink-0"
+      >
+        {isFullscreen ? <FullscreenExitIcon /> : <FullscreenEnterIcon />}
+      </button>
 
       <audio
         ref={audioRef}

--- a/src/components/book/mobile-book-display.tsx
+++ b/src/components/book/mobile-book-display.tsx
@@ -130,6 +130,7 @@ const MobileBookDisplay = ({ bookData }: { bookData: BookData }) => {
           {bookData.title}
         </h1>
       </div>
+      <AdBannersWrapper />
 
       {/* 페이지 컨텐츠 */}
       <div
@@ -144,7 +145,6 @@ const MobileBookDisplay = ({ bookData }: { bookData: BookData }) => {
             position="left"
             onPlayAudio={playTts}
           />
-          <AdBannersWrapper />
         </div>
       </div>
 

--- a/src/components/book/mobile-book-display.tsx
+++ b/src/components/book/mobile-book-display.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { BookData } from '@/types/api';
+import { useEffect, useRef, useState } from 'react';
+import BookPage from '@/components/book/book-page';
+
+const MobileBookDisplay = ({ bookData }: { bookData: BookData }) => {
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
+  const [touchStart, setTouchStart] = useState(0);
+  const [touchEnd, setTouchEnd] = useState(0);
+  const audioRef = useRef<HTMLAudioElement>(null);
+
+  const minSwipeDistance = 50; //최소 스와이프 거리
+
+  useEffect(() => {
+    // 다음 페이지 미리 로드
+    const preloadNextImages = (startIndex: number) => {
+      const pagesToPreload = bookData.pages.slice(
+        startIndex + 1,
+        startIndex + 3
+      );
+      pagesToPreload.forEach((page) => {
+        if (page.imageUrl) {
+          const img = new Image();
+          img.src = page.imageUrl;
+        }
+      });
+    };
+
+    preloadNextImages(currentPageIndex);
+  }, [currentPageIndex, bookData.pages]);
+
+  if (bookData.pages.length === 0) {
+    return <div className="p-4 text-center">이 책에는 페이지가 없습니다.</div>;
+  }
+
+  const currentPage = bookData.pages[currentPageIndex];
+  const isFirstPage = currentPageIndex === 0;
+  const isLastPage = currentPageIndex === bookData.pages.length - 1;
+
+  const goToPreviousPage = () => {
+    if (!isFirstPage) {
+      setCurrentPageIndex((prev) => prev - 1);
+    }
+  };
+
+  const goToNextPage = () => {
+    if (!isLastPage) {
+      setCurrentPageIndex((prev) => prev + 1);
+    }
+  };
+
+  const onTouchStart = (e: React.TouchEvent) => {
+    setTouchEnd(0); // 초기화
+    setTouchStart(e.targetTouches[0].clientX);
+  };
+
+  const onTouchMove = (e: React.TouchEvent) => {
+    setTouchEnd(e.targetTouches[0].clientX);
+  };
+
+  const onTouchEnd = () => {
+    if (!touchStart || !touchEnd) return;
+
+    const distance = touchStart - touchEnd;
+    const isLeftSwipe = distance > minSwipeDistance;
+    const isRightSwipe = distance < -minSwipeDistance;
+
+    if (isLeftSwipe && !isLastPage) {
+      goToNextPage();
+    }
+    if (isRightSwipe && !isFirstPage) {
+      goToPreviousPage();
+    }
+  };
+
+  const playTts = (audioUrl: string) => {
+    if (audioRef.current) {
+      const audioPlayer = audioRef.current;
+
+      if (!audioPlayer.paused && audioPlayer.src !== audioUrl) {
+        audioPlayer.pause();
+        audioPlayer.currentTime = 0;
+      }
+
+      audioPlayer.src = audioUrl;
+      audioPlayer
+        .play()
+        .catch((error) => console.error('오디오 재생 중 오류 발생:', error));
+    }
+  };
+
+  return (
+    <div className="w-full min-h-screen flex md:hidden flex-col bg-gray-100 pb-20">
+      {/* 헤더 */}
+      <div className="bg-white border-b border-gray-200 p-4 sticky top-0 z-10 shadow-sm">
+        <h1 className="text-xl font-bold text-gray-800 text-center">
+          {bookData.title}
+        </h1>
+      </div>
+
+      {/* 페이지 컨텐츠 */}
+      <div
+        className="flex-1 flex items-center justify-center p-4"
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+      >
+        <div className="w-full max-w-md">
+          <BookPage
+            pageData={currentPage}
+            position="left"
+            onPlayAudio={playTts}
+          />
+        </div>
+      </div>
+
+      {/* 하단 내비게이션 */}
+      <div className="fixed bottom-20 left-0 right-0 p-4">
+        <div className="flex items-center justify-between max-w-md mx-auto">
+          {/* 이전 페이지 버튼 */}
+          <button
+            onClick={goToPreviousPage}
+            disabled={isFirstPage}
+            className="bg-blue-500 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg transition hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+          >
+            <span className="text-xl">{'<'}</span>
+          </button>
+
+          {/* 현재 페이지 정보 */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-gray-600">
+              {currentPageIndex + 1} / {bookData.pages.length}
+            </span>
+            {/* 페이지 진행 상황 */}
+            <div className="flex gap-1">
+              {bookData.pages.map((_, index) => (
+                <div
+                  key={index}
+                  className={`w-2 h-2 rounded-full transition-all ${
+                    index === currentPageIndex
+                      ? 'bg-blue-500 w-6'
+                      : 'bg-gray-300'
+                  }`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* 다음 페이지 */}
+          <button
+            onClick={goToNextPage}
+            disabled={isLastPage}
+            className="bg-blue-500 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg transition hover:bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
+          >
+            <span className="text-xl">{'>'}</span>
+          </button>
+        </div>
+      </div>
+
+      <audio
+        ref={audioRef}
+        controls
+        className="hidden"
+      />
+    </div>
+  );
+};
+
+export default MobileBookDisplay;

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -9,7 +9,7 @@ const Footer = () => {
     'text-gray-500 transition-colors duration-200 hover:text-blue-500 hover:underline';
 
   return (
-    <footer className="w-full bg-gray-50 border-t border-gray-200 text-sm text-gray-500">
+    <footer className="hidden md:block w-full bg-gray-50 border-t border-gray-200 text-sm text-gray-500">
       <div className="max-w-6xl mx-auto py-16 px-8">
         <div className="flex flex-wrap justify-between gap-8 mb-12">
           {/* --- 프로젝트 섹션 --- */}

--- a/src/components/layout/mobile-footer-info.tsx
+++ b/src/components/layout/mobile-footer-info.tsx
@@ -1,0 +1,104 @@
+import Link from 'next/link';
+import { FaGithub, FaInstagram } from 'react-icons/fa';
+
+const MobileFooterInfo = () => {
+  const currentYear = new Date().getFullYear();
+
+  const linkStyles =
+    'text-gray-600 transition-colors duration-200 hover:text-blue-500';
+
+  return (
+    <footer className="md:hidden w-full bg-gray-50 border-t border-gray-200 mt-12 pb-20">
+      <div className="px-6 py-8">
+        {/* 프로젝트 섹션 */}
+        <div className="mb-6">
+          <h3 className="text-sm font-semibold text-gray-800 mb-3">
+            프로젝트
+          </h3>
+          <ul className="space-y-2 text-sm">
+            <li>
+              <Link href="/about" className={linkStyles}>
+                서비스 소개
+              </Link>
+            </li>
+            <li>
+              <Link href="/team" className={linkStyles}>
+                만든 사람들
+              </Link>
+            </li>
+            <li>
+              <Link href="/faq" className={linkStyles}>
+                자주 묻는 질문
+              </Link>
+            </li>
+          </ul>
+        </div>
+
+        {/* 지원 섹션 */}
+        <div className="mb-6">
+          <h3 className="text-sm font-semibold text-gray-800 mb-3">지원</h3>
+          <ul className="space-y-2 text-sm">
+            <li>
+              <Link href="/contact" className={linkStyles}>
+                문의하기
+              </Link>
+            </li>
+            <li>
+              <Link href="/help" className={linkStyles}>
+                도움말 센터
+              </Link>
+            </li>
+          </ul>
+        </div>
+
+        {/* 법적 고지 섹션 */}
+        <div className="mb-6">
+          <h3 className="text-sm font-semibold text-gray-800 mb-3">
+            법적 고지
+          </h3>
+          <ul className="space-y-2 text-sm">
+            <li>
+              <Link href="/terms" className={linkStyles}>
+                이용약관
+              </Link>
+            </li>
+            <li>
+              <Link href="/privacy" className={linkStyles}>
+                개인정보처리방침
+              </Link>
+            </li>
+          </ul>
+        </div>
+
+        {/* Copyright & SNS */}
+        <div className="pt-6 border-t border-gray-200">
+          <p className="text-xs text-gray-500 mb-4">
+            © {currentYear} 나의 동화책. All rights reserved.
+          </p>
+          <div className="flex gap-4">
+            <Link
+              href="https://github.com/my-fairy-tale"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Github"
+              className="text-gray-500 hover:text-blue-500"
+            >
+              <FaGithub size={20} />
+            </Link>
+            <Link
+              href="https://twitter.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Instagram"
+              className="text-gray-500 hover:text-blue-500"
+            >
+              <FaInstagram size={20} />
+            </Link>
+          </div>
+        </div>
+      </div>
+    </footer>
+  );
+};
+
+export default MobileFooterInfo;

--- a/src/components/layout/mobile-footer.tsx
+++ b/src/components/layout/mobile-footer.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { FiHome, FiBookOpen, FiGrid, FiActivity, FiUser } from 'react-icons/fi';
+
+const navItems = [
+  { href: '/', label: 'Home', icon: FiHome },
+  { href: '/books', label: '만들기', icon: FiBookOpen },
+  { href: '/library', label: '서재', icon: FiGrid },
+  { href: '/activity', label: '활동', icon: FiActivity },
+  { href: '/mypage', label: 'MY', icon: FiUser },
+];
+
+export default function MobileFooter() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="md:hidden fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 z-50">
+      <div className="flex items-center justify-around h-16 px-2">
+        {navItems.map((item) => {
+          const isActive =
+            item.href === '/'
+              ? pathname === item.href
+              : pathname.startsWith(item.href);
+          const Icon = item.icon;
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`flex flex-col items-center justify-center flex-1 h-full gap-1 transition-colors ${
+                isActive
+                  ? 'text-blue-600'
+                  : 'text-gray-500 hover:text-gray-900'
+              }`}
+            >
+              <Icon size={22} strokeWidth={isActive ? 2.5 : 2} />
+              <span className={`text-xs ${isActive ? 'font-semibold' : 'font-medium'}`}>
+                {item.label}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/mypage/user-profile.tsx
+++ b/src/components/mypage/user-profile.tsx
@@ -156,7 +156,7 @@ const UserProfile = () => {
       <section>
         <h2 className="text-xl font-semibold mb-4 text-gray-800">내 정보</h2>
         <div className="bg-white p-6 rounded-lg shadow-md flex items-center justify-between space-x-6">
-          <div className="flex items-center space-x-6">
+          <div className="flex items-center justify-between space-x-6">
             <FaUserCircle
               size={80}
               className="text-gray-300"
@@ -220,11 +220,13 @@ const UserProfile = () => {
           <div>
             {user.canCreateBookToday ? (
               <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800 whitespace-nowrap">
-                ✓ 오늘 책 생성 가능
+                <span className="hidden md:flex md:mr-1">✓ 오늘 책 </span>생성
+                가능
               </span>
             ) : (
               <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800 whitespace-nowrap">
-                ✗ 오늘 책 생성 불가
+                <span className="hidden md:flex md:mr-1">✗ 오늘 책 </span>생성
+                불가
               </span>
             )}
           </div>

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * CSS 미디어 쿼리를 리액트 훅으로 사용할 수 있게 해주는 커스텀 훅
+ *
+ * @param query - CSS 미디어 쿼리 문자열 (예: '(max-width: 768px)')
+ * @returns 미디어 쿼리가 매칭되는지 여부 (boolean | null)
+ *          - true: 미디어 쿼리 매칭됨
+ *          - false: 미디어 쿼리 매칭되지 않음
+ *          - null: 초기 렌더링 (SSR 대응)
+ *
+ * @example
+ * const isMobile = useMediaQuery('(max-width: 767px)');
+ * if (isMobile === null) return null; // SSR 대응
+ * return isMobile ? <MobileView /> : <DesktopView />;
+ */
+export const useMediaQuery = (query: string): boolean | null => {
+  const [matches, setMatches] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      setMatches(e.matches);
+    };
+
+    // 초기값 설정
+    handleChange(mediaQuery);
+
+    // 이벤트 리스너 등록
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [query]);
+
+  return matches;
+};
+
+/**
+ * 모바일 화면인지 확인하는 헬퍼 훅
+ * Tailwind의 md breakpoint (768px)를 기준으로 함
+ *
+ * @returns 모바일 화면 여부 (boolean | null)
+ *
+ * @example
+ * const isMobile = useIsMobile();
+ * if (isMobile === null) return null;
+ * return isMobile ? <MobileLayout /> : <DesktopLayout />;
+ */
+export const useIsMobile = (): boolean | null => {
+  return useMediaQuery('(max-width: 767px)');
+};
+
+/**
+ * 태블릿 화면인지 확인하는 헬퍼 훅
+ * Tailwind의 md ~ lg breakpoint (768px ~ 1023px)를 기준으로 함
+ *
+ * @returns 태블릿 화면 여부 (boolean | null)
+ */
+export const useIsTablet = (): boolean | null => {
+  return useMediaQuery('(min-width: 768px) and (max-width: 1023px)');
+};
+
+/**
+ * 데스크톱 화면인지 확인하는 헬퍼 훅
+ * Tailwind의 lg breakpoint (1024px) 이상을 기준으로 함
+ *
+ * @returns 데스크톱 화면 여부 (boolean | null)
+ */
+export const useIsDesktop = (): boolean | null => {
+  return useMediaQuery('(min-width: 1024px)');
+};

--- a/src/lib/adfit-script-manager.ts
+++ b/src/lib/adfit-script-manager.ts
@@ -71,9 +71,10 @@ class AdfitScriptManager {
         if (this.script.onload) {
           // 기존 onload 래핑
           const originalOnload = this.script.onload;
+          const script = this.script; // null 체크를 위한 로컬 변수
           this.script.onload = (ev) => {
             if (typeof originalOnload === 'function') {
-              originalOnload.call(this.script, ev);
+              originalOnload.call(script, ev);
             }
             onExistingScriptLoad();
           };

--- a/src/lib/adfit-script-manager.ts
+++ b/src/lib/adfit-script-manager.ts
@@ -1,0 +1,153 @@
+type LoadCallback = () => void;
+
+class AdfitScriptManager {
+  private script: HTMLScriptElement | null = null;
+  private refCount = 0;
+  private isLoaded = false;
+  private loadCallbacks: LoadCallback[] = [];
+  private readonly scriptSrc = '//t1.daumcdn.net/kas/static/ba.min.js';
+
+  /**
+   * 스크립트를 로드하고 참조 카운트를 증가시킵니다.
+   * @param callback 스크립트 로드 완료 후 실행할 콜백 (선택사항)
+   */
+  load(callback?: LoadCallback): void {
+    this.refCount++;
+
+    // 콜백이 있으면 처리
+    if (callback) {
+      if (this.isLoaded) {
+        // 이미 로드 완료됨 - 즉시 실행
+        callback();
+      } else {
+        // 로드 대기 중 - 큐에 추가
+        this.loadCallbacks.push(callback);
+      }
+    }
+
+    // 스크립트가 이미 있으면 생성하지 않음
+    if (this.script) return;
+
+    // DOM에서 기존 스크립트 찾기 (다른 곳에서 추가했을 수도 있음)
+    this.script = document.querySelector<HTMLScriptElement>(
+      `script[src="${this.scriptSrc}"]`
+    );
+
+    if (!this.script) {
+      // 스크립트가 없으면 새로 생성
+      this.script = document.createElement('script');
+      this.script.src = this.scriptSrc;
+      this.script.async = true;
+
+      // 로드 완료 시 콜백 실행
+      this.script.onload = () => {
+        this.isLoaded = true;
+        // 대기 중인 모든 콜백 실행
+        this.loadCallbacks.forEach((cb) => cb());
+        this.loadCallbacks = [];
+      };
+
+      // 에러 처리
+      this.script.onerror = () => {
+        console.error('카카오 애드핏 스크립트 로드 실패');
+        this.isLoaded = false;
+        this.loadCallbacks = [];
+      };
+
+      document.body.appendChild(this.script);
+    } else {
+      // 스크립트는 DOM에 있지만 로드 완료 여부 확인
+      if ('adfit' in window) {
+        this.isLoaded = true;
+        if (callback) callback();
+      } else {
+        // 스크립트가 로딩 중일 수 있으므로 onload 리스너 추가
+        const onExistingScriptLoad = () => {
+          this.isLoaded = true;
+          this.loadCallbacks.forEach((cb) => cb());
+          this.loadCallbacks = [];
+        };
+
+        if (this.script.onload) {
+          // 기존 onload 래핑
+          const originalOnload = this.script.onload;
+          this.script.onload = (ev) => {
+            if (typeof originalOnload === 'function') {
+              originalOnload.call(this.script, ev);
+            }
+            onExistingScriptLoad();
+          };
+        } else {
+          this.script.onload = onExistingScriptLoad;
+        }
+      }
+    }
+  }
+
+  /**
+   * 참조 카운트를 감소시키고 광고를 정리합니다.
+   * 모든 참조가 사라지면 스크립트를 DOM에서 제거합니다.
+   * @param adUnit 정리할 광고 유닛 ID
+   */
+  unload(adUnit: string): void {
+    this.refCount--;
+
+    // adfit.destroy 호출하여 광고 정리
+    const globalAdfit = 'adfit' in window ? window.adfit : null;
+    if (globalAdfit && globalAdfit.destroy) {
+      globalAdfit.destroy(adUnit);
+    }
+
+    // 모든 참조가 사라지면 스크립트 제거
+    if (this.refCount === 0 && this.script) {
+      if (this.script.parentNode) {
+        this.script.parentNode.removeChild(this.script);
+      }
+      this.script = null;
+      this.isLoaded = false;
+      this.loadCallbacks = [];
+    }
+
+    // 참조 카운트가 음수가 되지 않도록 보호
+    if (this.refCount < 0) {
+      console.warn('AdfitScriptManager: refCount가 음수입니다. 리셋합니다.');
+      this.refCount = 0;
+    }
+  }
+
+  /**
+   * 현재 참조 카운트를 반환합니다.
+   * @returns 현재 참조 카운트
+   */
+  getRefCount(): number {
+    return this.refCount;
+  }
+
+  /**
+   * 스크립트 로드 완료 여부를 반환합니다.
+   * @returns 로드 완료 여부
+   */
+  isScriptLoaded(): boolean {
+    return this.isLoaded;
+  }
+
+  /**
+   * 대기 중인 콜백 수를 반환합니다.
+   * @returns 대기 중인 콜백 수
+   */
+  getPendingCallbacksCount(): number {
+    return this.loadCallbacks.length;
+  }
+}
+
+// 싱글톤 인스턴스 export
+export const adfitScriptManager = new AdfitScriptManager();
+
+// TypeScript 타입 선언
+declare global {
+  interface Window {
+    adfit?: {
+      destroy?: (unit: string) => void;
+    };
+  }
+}


### PR DESCRIPTION
## 요약

카카오 애드핏 광고 시스템을 구현하고, PC/Mobile 반응형 처리 및 화면 전환 시 광고가 정상적으로 표시되도록 동적 스크립트 로딩 방식을 적용했습니다.

### 🎯 주요 기능
- 카카오 애드핏 광고 배너 컴포넌트 구현 (PC/Mobile 분리)
- 동적 스크립트 로딩으로 화면 전환 시 광고 재초기화
- 조건부 렌더링으로 PC/Mobile 컴포넌트 관리
- 여러 페이지에 광고 배너 적용 (books, library, activity 등)

### 🏗️ 아키텍처 개선
- 각 배너 컴포넌트가 자체적으로 스크립트 관리
- useEffect cleanup 패턴으로 메모리 누수 방지
- adfit.destroy() 호출로 광고 유닛 정리
- 조건부 렌더링으로 불필요한 DOM 생성 방지

### 🎨 UI/UX 개선
- PC: 728x90 배너, Mobile: 320x50 배너 (각 화면에 최적화)
- 화면 전환 시 깜빡임 없이 자연스러운 광고 표시
- SSR 대응으로 초기 렌더링 깜빡임 방지

### 🐛 버그 수정
- PC에서 Mobile 전환 시 광고가 표시되지 않던 문제 해결
- hidden으로 숨긴 배너가 초기화되지 않던 문제 해결
- Mobile에서 PC 컴포넌트의 광고가 표시되던 문제 해결

## 테스트 플랜

- [x] PC 화면에서 페이지 로드 시 광고 정상 표시 확인
- [x] Mobile 화면에서 페이지 로드 시 광고 정상 표시 확인
- [x] 개발자 도구로 PC ↔ Mobile 화면 전환 시 광고 재로드 확인
- [x] 여러 페이지에서 광고 배너 정상 작동 확인 (books, library, activity 등)
- [x] 컴포넌트 언마운트 시 스크립트 및 광고 정리 확인 (메모리 누수 체크)

## 기술적 세부사항

### 새로 추가된 파일
- `src/components/ad/ad-banner.tsx` - 광고 배너 기본 컴포넌트 (동적 스크립트 로딩)
- `src/components/ad/ad-banner-pc.tsx` - PC용 광고 배너 래퍼
- `src/components/ad/ad-banner-mobile.tsx` - Mobile용 광고 배너 래퍼
- `src/components/ad/ad-banners-wrapper.tsx` - 반응형 광고 배너 래퍼 (조건부 렌더링)
- `src/components/ad/ad-sidebar.tsx` - 사이드바 광고 컴포넌트
- `src/docs/kakao-adfit-responsive-rendering-issue.md` - 문제 해결 과정 문서화

### 수정된 파일
- `src/components/book/book-fetching.tsx` - 조건부 렌더링으로 PC/Mobile 분리
- `src/components/book/book-display.tsx` - 광고 배너 추가
- `src/components/book/mobile-book-display.tsx` - 광고 배너 추가, 전체화면 기능
- `src/app/books/page.tsx` - 광고 배너 추가
- `src/app/library/[slug]/page.tsx` - 광고 배너 추가
- `src/app/library/page.tsx` - 광고 배너 추가
- `src/app/activity/page.tsx` - 광고 배너 추가
- 기타 페이지들에 광고 배너 추가

### Breaking Changes
- 없음

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)